### PR TITLE
Credentials obtained automatically when run in ACR Tasks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,9 @@ RUN make binaries && mv bin/acr /usr/bin/acr
 FROM alpine:3.9.4
 RUN apk --update add ca-certificates
 COPY --from=acr-cli /usr/bin/acr /usr/bin/acr
-ENTRYPOINT [ "acr" ]
+RUN apk add --no-cache \
+	bash \
+	jq \
+	curl
+COPY ./acr.sh /acrscripts/acr.sh
+ENTRYPOINT [ "bash","/acrscripts/acr.sh" ]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # Azure Container Registry CLI
 
-[![Build Status](https://travis-ci.org/AzureCR/acr-cli.svg?branch=master)](https://travis-ci.org/Azure/acr-cli)
+[![Build Status](https://travis-ci.org/Azure/acr-cli.svg?branch=master)](https://travis-ci.org/Azure/acr-cli)
 
 This repository contains the source code for CLI components for Azure Container Registry.
 

--- a/acr.sh
+++ b/acr.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+AGO=7d
+while getopts "r:a:f:n:d" OPTION; do
+  case $OPTION in
+    r )
+      REGISTRY=$OPTARG
+      ;;
+    a ) 
+      AGO=$OPTARG
+      ;;
+    f ) 
+      FILTER=$OPTARG
+      ;;
+    n ) 
+      REPOSITORY=$OPTARG
+      ;;
+    d )
+      DANGLING=1
+      ;;
+    ? ) 
+        echo "ERR: Usage: acr.sh -r <REGISTRY> -n <REPOSITORY_NAME> -a <AGO> -f <FILTER>"
+        exit 1
+      ;;
+  esac
+done
+
+if [ -z "$REPOSITORY" ]
+   then
+      echo ERR: -r Repository not set. 
+      exit 1
+fi
+
+export ACR_REFRESH_TOKEN=$(cat ~/.docker/config.json | jq -r --arg r $REGISTRY '.auths[$r].identitytoken')
+export SCOPE="repository:*:*"
+export ACR_ACCESS_TOKEN=$(curl --silent -X POST -H "Content-Type: application/x-www-form-urlencoded" -d "grant_type=refresh_token&service=$REGISTRY&scope=$SCOPE&refresh_token=$ACR_REFRESH_TOKEN" https://$REGISTRY/oauth2/token | jq -r '.access_token')
+
+if [ -z "$ACR_ACCESS_TOKEN" ]
+    then
+        echo ERR: Unable to resolve authentication
+        exit 1
+fi
+
+if [ -z "$FILTER" ]
+  then
+    if (($DANGLING))
+      then
+          acr purge -r $REGISTRY --ago $AGO --repository $REPOSITORY --access-token $ACR_ACCESS_TOKEN --dangling
+      else
+          acr purge -r $REGISTRY --ago $AGO --repository $REPOSITORY --access-token $ACR_ACCESS_TOKEN 
+    fi
+  else
+    if (($DANGLING))
+      then
+          acr purge -r $REGISTRY --ago $AGO --filter $FILTER --repository $REPOSITORY --access-token $ACR_ACCESS_TOKEN --dangling
+      else
+          acr purge -r $REGISTRY --ago $AGO --filter $FILTER --repository $REPOSITORY --access-token $ACR_ACCESS_TOKEN 
+    fi
+fi

--- a/cmd/api/acrsdk.go
+++ b/cmd/api/acrsdk.go
@@ -20,6 +20,11 @@ const (
 	registryURL = ".azurecr.io"
 )
 
+// BearerAuth returns the authentication header in case an access token was specified.
+func BearerAuth(accessToken string) string {
+	return "Bearer " + accessToken
+}
+
 // BasicAuth returns the username and the passwrod encoded in base 64.
 func BasicAuth(username string, password string) string {
 	auth := username + ":" + password

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/AzureCR/acr-cli
+module github.com/Azure/acr-cli
 
 go 1.12
 

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,6 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 contrib.go.opencensus.io/exporter/ocagent v0.4.12 h1:jGFvw3l57ViIVEPKKEUXPcLYIXJmQxLUh6ey1eJhwyc=
 contrib.go.opencensus.io/exporter/ocagent v0.4.12/go.mod h1:450APlNTSR6FrvC3CTRqYosuDstRB9un7SOx2k/9ckA=
-github.com/Azure/acr-cli v0.0.0-20190626010725-05e800ba8517 h1:VgQMVqWavyqCa+wrPlE09SWACMLlp9sItYB2GwhuywY=
 github.com/Azure/go-autorest/autorest v0.2.0 h1:zBtSTOQTtjzHVRe+mhkiHvHwRTKHhjBEyo1m6DfI3So=
 github.com/Azure/go-autorest/autorest v0.2.0/go.mod h1:AKyIcETwSUFxIcs/Wnq/C+kwCtlEYGUVd7FPNb2slmg=
 github.com/Azure/go-autorest/autorest/adal v0.1.0 h1:RSw/7EAullliqwkZvgIGDYZWQm1PGKXI8c4aY/87yuU=


### PR DESCRIPTION
When run inside an ACR task the container image is now able to receive the credentials from the task.
An example of a run is
az acr run --cmd "{{ .Run.Registry }}/purge:latest -r {{ .Run.Registry }} -n reponame -a 10d -f '^hello.*'" /dev/null
This would delete all tags that are older than 10 days and their names begin with hello
(Assuming the acr-cli is built as a docker image named /purge:latest in the same registry)

Fixes #3 