### PR TITLE
Rename WorkerError to workerError

### DIFF
--- a/cmd/worker/collector.go
+++ b/cmd/worker/collector.go
@@ -8,7 +8,7 @@ var JobQueue = make(chan PurgeJob, 100)
 
 // ErrorChannel is a channel for communication with the cobra command to verify
 // that no errors have happened so far.
-var ErrorChannel = make(chan WorkerError, 100)
+var ErrorChannel = make(chan workerError, 100)
 
 // QueuePurgeTag creates a PurgeTag job and queues it.
 func QueuePurgeTag(loginURL string,

--- a/cmd/worker/purge_structures.go
+++ b/cmd/worker/purge_structures.go
@@ -24,8 +24,8 @@ const (
 	PurgeManifest JobTypeEnum = "purgemanifest"
 )
 
-// WorkerError describes an error which occured inside a worker.
-type WorkerError struct {
+// workerError describes an error which occured inside a worker.
+type workerError struct {
 	JobType JobTypeEnum
 	Error   error
 }

--- a/cmd/worker/worker.go
+++ b/cmd/worker/worker.go
@@ -60,12 +60,12 @@ func (pw *PurgeWorker) Stop() {
 func (pw *PurgeWorker) ProcessJob(ctx context.Context, job PurgeJob) {
 	go func() {
 		defer pw.wg.Done()
-		var wErr WorkerError
+		var wErr workerError
 		switch job.JobType {
 		case PurgeTag:
 			err := api.AcrDeleteTag(ctx, job.LoginURL, job.Auth, job.RepoName, job.Tag)
 			if err != nil {
-				wErr = WorkerError{
+				wErr = workerError{
 					JobType: PurgeTag,
 					Error:   err,
 				}
@@ -75,7 +75,7 @@ func (pw *PurgeWorker) ProcessJob(ctx context.Context, job PurgeJob) {
 		case PurgeManifest:
 			err := api.DeleteManifest(ctx, job.LoginURL, job.Auth, job.RepoName, job.Digest)
 			if err != nil {
-				wErr = WorkerError{
+				wErr = workerError{
 					JobType: PurgeTag,
 					Error:   err,
 				}


### PR DESCRIPTION
**Purpose of the PR**

- Running `make` fails for the project right now:

> cmd/worker/purge_structures.go:28:6: type name will be used as worker.WorkerError by other packages, and that stutters; consider calling this Error (golint)

- Rename WorkerError to `workerError`, since it doesn't need to be exported right now. Otherwise it could be renamed as just `Error`
