### PR TITLE
Lookup for environment variable added

### DIFF
--- a/cmd/acr/manifest.go
+++ b/cmd/acr/manifest.go
@@ -55,7 +55,11 @@ func newManifestListCmd(out io.Writer, manifestParams *manifestParameters) *cobr
 		Short: "List manifests from a repository",
 		Long:  newManifestListCmdLongMessage,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			loginURL := api.LoginURL(manifestParams.registryName)
+			registryName, err := manifestParams.GetRegistryName()
+			if err != nil {
+				return err
+			}
+			loginURL := api.LoginURL(registryName)
 			acrClient, err := api.GetAcrCLIClientWithAuth(loginURL, manifestParams.username, manifestParams.password, manifestParams.configs)
 			if err != nil {
 				return err
@@ -96,7 +100,11 @@ func newManifestDeleteCmd(out io.Writer, manifestParams *manifestParameters) *co
 		Short: "Delete tags from a repository",
 		Long:  newManifestDeleteCmdLongMessage,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			loginURL := api.LoginURL(manifestParams.registryName)
+			registryName, err := manifestParams.GetRegistryName()
+			if err != nil {
+				return err
+			}
+			loginURL := api.LoginURL(registryName)
 			acrClient, err := api.GetAcrCLIClientWithAuth(loginURL, manifestParams.username, manifestParams.password, manifestParams.configs)
 			if err != nil {
 				return err

--- a/cmd/acr/purge.go
+++ b/cmd/acr/purge.go
@@ -57,7 +57,11 @@ func newPurgeCmd(out io.Writer, rootParams *rootParameters) *cobra.Command {
 		Example: purgeExampleMessage,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
-			loginURL := api.LoginURL(purgeParams.registryName)
+			registryName, err := purgeParams.GetRegistryName()
+			if err != nil {
+				return err
+			}
+			loginURL := api.LoginURL(registryName)
 			acrClient, err := api.GetAcrCLIClientWithAuth(loginURL, purgeParams.username, purgeParams.password, purgeParams.configs)
 			if err != nil {
 				return err

--- a/cmd/acr/root.go
+++ b/cmd/acr/root.go
@@ -4,6 +4,9 @@
 package main
 
 import (
+	"errors"
+	"os"
+
 	"github.com/spf13/cobra"
 )
 
@@ -44,4 +47,17 @@ To start working with the CLI, run acr --help`,
 
 	_ = flags.Parse(args)
 	return cmd
+}
+
+// GetRegistryName if the registry flag was not specified it tries to get the registry value from an environment
+// variable, if that fails then an error is returned.
+func (rootParams *rootParameters) GetRegistryName() (string, error) {
+	if len(rootParams.registryName) > 0 {
+		return rootParams.registryName, nil
+	} else {
+		if registryName, ok := os.LookupEnv("ACR_DEFAULT_REGISTRY"); ok {
+			return registryName, nil
+		}
+		return "", errors.New("unable to determine registry name, please use --registry flag")
+	}
 }

--- a/cmd/acr/tag.go
+++ b/cmd/acr/tag.go
@@ -55,7 +55,11 @@ func newTagListCmd(out io.Writer, tagParams *tagParameters) *cobra.Command {
 		Short: "List tags from a repository",
 		Long:  newTagListCmdLongMessage,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			loginURL := api.LoginURL(tagParams.registryName)
+			registryName, err := tagParams.GetRegistryName()
+			if err != nil {
+				return err
+			}
+			loginURL := api.LoginURL(registryName)
 			acrClient, err := api.GetAcrCLIClientWithAuth(loginURL, tagParams.username, tagParams.password, tagParams.configs)
 			if err != nil {
 				return err
@@ -94,7 +98,11 @@ func newTagDeleteCmd(out io.Writer, tagParams *tagParameters) *cobra.Command {
 		Short: "Delete tags from a repository",
 		Long:  newTagDeleteCmdLongMessage,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			loginURL := api.LoginURL(tagParams.registryName)
+			registryName, err := tagParams.GetRegistryName()
+			if err != nil {
+				return err
+			}
+			loginURL := api.LoginURL(registryName)
 			acrClient, err := api.GetAcrCLIClientWithAuth(loginURL, tagParams.username, tagParams.password, tagParams.configs)
 			if err != nil {
 				return err


### PR DESCRIPTION
If the registry flag is not specified the program looks for the ACR_DEFAULT_REGISTRY environment variable instead, making the registry flag not required.

- 

Fixes #33 
Fixes #34