### PR TITLE
Refresh of jwt tokens added

### DIFF
--- a/cmd/acr/manifest.go
+++ b/cmd/acr/manifest.go
@@ -112,7 +112,7 @@ func newManifestDeleteCmd(out io.Writer, manifestParams *manifestParameters) *co
 			ctx := context.Background()
 
 			for i := 0; i < len(args); i++ {
-				err := acrClient.DeleteManifest(ctx, manifestParams.repoName, args[i])
+				_, err := acrClient.DeleteManifest(ctx, manifestParams.repoName, args[i])
 				if err != nil {
 					return errors.Wrap(err, "failed to delete manifests")
 				}

--- a/cmd/acr/purge.go
+++ b/cmd/acr/purge.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"net/http"
 	"regexp"
 	"strings"
 	"sync"
@@ -217,6 +218,10 @@ func GetTagsToDelete(ctx context.Context,
 	var lastUpdateTime time.Time
 	resultTags, err := acrClient.GetAcrTags(ctx, repoName, "", lastTag)
 	if err != nil {
+		if resultTags.StatusCode == http.StatusNotFound {
+			fmt.Printf("%s repository not found\n", repoName)
+			return nil, "", nil
+		}
 		return nil, "", err
 	}
 	newLastTag := ""

--- a/cmd/acr/tag.go
+++ b/cmd/acr/tag.go
@@ -110,7 +110,7 @@ func newTagDeleteCmd(out io.Writer, tagParams *tagParameters) *cobra.Command {
 			ctx := context.Background()
 
 			for i := 0; i < len(args); i++ {
-				err := acrClient.DeleteAcrTag(ctx, tagParams.repoName, args[i])
+				_, err := acrClient.DeleteAcrTag(ctx, tagParams.repoName, args[i])
 				if err != nil {
 					return errors.Wrap(err, "failed to delete tags")
 				}

--- a/cmd/api/acrsdk_test.go
+++ b/cmd/api/acrsdk_test.go
@@ -39,3 +39,22 @@ func TestLoginURL(t *testing.T) {
 		t.Fatalf("LoginURL of %s incorrect, got %s, expected %s", registryName, loginURL, expectedReturn)
 	}
 }
+
+func TestGetExpiration(t *testing.T) {
+	// EmptyToken contains no authentication data
+	testToken := "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJUZXN0VG9rZW4iLCJpYXQiOjE1NjM5MDk2NTIsImV4cCI6MTU2MzkxMDk4MSwiYXVkIjoiZXhhbXBsZS5henVyZWNyLmlvIiwic3ViIjoiZXhhbXBsZUBleGFtcGxlLmNvbSJ9.Ivw5oOSwMZYGKCzlogsguIIH9UDmKXIixdlgXEfo2dk" //nolint:gosec
+	expectedReturn := int64(1563910981)
+	exp, err := getExpiration(testToken)
+	if err != nil {
+		t.Fatal("Unexpected error while parsing token")
+	}
+	if exp != expectedReturn {
+		t.Fatalf("getExpiration incorrect, got %d, expected %d", exp, expectedReturn)
+	}
+
+	testToken = "token"
+	_, err = getExpiration(testToken)
+	if err == nil {
+		t.Fatal("Expected error while parsing token, got nil")
+	}
+}


### PR DESCRIPTION
This PR adds token refreshing when using bearer authentication, also when a repository is not found or an image is not found or locked the program just prints the issue, instead of returning an error

- 

Fixes #35 
Fixes #38