### PR TITLE
Fix cli arguments for `az acr` and `docker build`

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ autorest autorest.md --output-sdk-folder=../acr --go
 ```
 
 For updating the vendor folder run (at repository root):
+
 ```sh
 make vendor
 ```
@@ -62,15 +63,17 @@ make vendor
 
 The following are examples of commands that the CLI currently supports.
 
-#### Login Command
+### Login Command
 
 If you are currently logged into an Azure Container Registry the program should be able to read your stored credentials, if not you can do:
+
 ```sh
 acr login <registry name>
 ```
+
 This login will also work with the [Docker CLI](https://github.com/docker/cli).
 
-#### Tag Command
+### Tag Command
 
 To list all the tags inside a repository
 
@@ -79,11 +82,12 @@ acr tag list -r <Registry Name> --repository <Repository Name>
 ```
 
 To delete a single tag from a repository
+
 ```sh
 acr tag delete -r <Registry Name> --repository <Repository Name> <Tag Names>
 ```
 
-#### Manifest Command
+### Manifest Command
 
 To list all the manifests inside a repository
 
@@ -92,13 +96,15 @@ acr manifest list -r <Registry Name> --repository <Repository Name>
 ```
 
 To delete a single manifest from a repository (and all the tags that are linked to it)
+
 ```sh
 acr manifest delete -r <Registry Name> --repository <Repository Name> <Manifest digests>
 ```
 
-#### Purge Command
+### Purge Command
 
 To delete all the tags that are older than a certain duration:
+
 ```sh
 acr purge \
     --registry <Registry Name> \
@@ -106,22 +112,23 @@ acr purge \
     --ago <Go Style Duration>
 ```
 
-##### Filter flag
+#### Filter flag
+
 The filter flag is used to specify the repository and a regex filter, if a tag is older than the duration specified by the ago flag and matches the regex filter then it is untagged, for example:
 
 Examples of filters
 
-| Intention                                                                      | Flag                                |
-|--------------------------------------------------------------------------------|-------------------------------------|
-| Untag all tags that begin with hello                                           | --filter `"<repository>:^hello.*"`  |
+| Intention                                                                      | Flag                                  |
+|--------------------------------------------------------------------------------|---------------------------------------|
+| Untag all tags that begin with hello                                           | --filter `"<repository>:^hello.*"`    |
 | Untag tags that end with world                                                 | --filter `"<repository>:\w*world\b"`  |
 | Untag tags that include hello-world in their name                              | --filter `"<repository>:hello-world"` |
 | Untag all tags that are older than the duration                                | --filter `"<repository>:.*"`          |
 
-
-##### Ago flag
+#### Ago flag
 
 The ago flag can be used to change the default expiration time of a tag, for example, the following command would purge all tags that are older than 30 days:
+
 ```sh
 acr purge \
     --registry <Registry Name> \
@@ -139,20 +146,24 @@ The following table further explains the functionality of this flag.
 
 The duration should be of the form \[integer\]d\[string\] where the first integer specifies the number of days and the string is in a go style duration (can be omitted)
 
-#### Optional purge flags
-##### Untagged flag
+### Optional purge flags
 
-To delete all the manifests that do not have any tags linked to them, the ```--untagged``` flag should be set.
+#### Untagged flag
+
+To delete all the manifests that do not have any tags linked to them, the `--untagged` flag should be set.
+
 ```sh
 acr purge \
     --registry <Registry Name> \
     --filter <Repository Name>:<Regex filter>
     --untagged
 ```
-##### Dry run flag
 
-To know which tags and manifests would be deleted the ```dry-run``` flag can be set, nothing will be deleted and the output would be the same as if the purge command was executed normally.
+#### Dry run flag
+
+To know which tags and manifests would be deleted the `dry-run` flag can be set, nothing will be deleted and the output would be the same as if the purge command was executed normally.
 An example of this would be:
+
 ```sh
 acr purge \
     --registry <Registry Name> \
@@ -165,22 +176,32 @@ acr purge \
 To run a locally built version of the ACR-CLI using ACR Tasks follow these steps:
 1. Build the docker image and push to an Azure Container Registry
 Either build and push manually:
+
 ```sh
-docker build -t <Registry Name>/acr:latest
+docker build -t <Registry Name>/acr:latest .
 docker push <Registry Name>/acr:latest
 ```
+
 Or using [ACR Build](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-tutorial-quick-task)
+
 ```sh
 az acr build -t acr:latest .
 ```
 
 2. Run it inside an ACR task (authentication is obtained through the task itself) by executing
-```sh
-az acr run --cmd "{{ .Run.Registry }}/acr:latest <ACR-CLI command>" /dev/null
-```
-For example to run the tag list command
+
 ```sh
 az acr run \
+    --registry <Registry Name> \
+    --cmd "{{ .Run.Registry }}/acr:latest <ACR-CLI command>" \
+    /dev/null
+```
+
+For example to run the tag list command
+
+```sh
+az acr run \
+    --registry <Registry Name> \
     --cmd "{{ .Run.Registry }}/acr:latest tag list -r {{ .Run.Registry }}
             --filter <Repository Name>:<Regex filter>" \
     /dev/null
@@ -188,20 +209,28 @@ az acr run \
 
 OR.
 Schedule a periodically repeating task using [ACR Scheduled Tasks](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-tasks-scheduled)
+
 ```sh
-az acr task create --name purgeTask \
+az acr task create \
+    --name purgeTask \
+    --registry <Registry Name> \
     --cmd "{{ .Run.Registry }}/acr:latest <ACR-CLI command>" \
     --context /dev/null \
     --schedule <CRON expression>
 ```
+
 For example to have a task that executes every day and purges tags older than 7 days one can execute:
+
 ```sh
-az acr task create --name purgeTask \
+az acr task create \
+    --name purgeTask \
+    --registry <Registry Name> \
     --cmd "{{ .Run.Registry }}/acr:latest purge -r {{ .Run.Registry }}
             --filter <Repository Name>:<Regex filter> --ago 7d" \
     --context /dev/null \
     --schedule "0 0 * * *"
 ```
+
 ## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a


### PR DESCRIPTION
**Purpose of the PR**

1. fixes the second `docker build` command which is missing a `.` as an argument
2. fixes the `az acr` commands which are missing the required parameter `--registry`
3. fixes minor formatting issues found by [mdl](https://github.com/markdownlint/markdownlint)
