### PR TITLE
Refactoring last tag from Link Header

### DIFF
--- a/cmd/acr/purge.go
+++ b/cmd/acr/purge.go
@@ -431,7 +431,7 @@ func dryRunPurge(ctx context.Context, acrClient api.AcrCLIClientInterface, login
 		if err != nil {
 			return -1, -1, err
 		}
-        lastTag = newLastTag
+		lastTag = newLastTag
 		if tagsToDelete != nil {
 			for _, tag := range *tagsToDelete {
 				// For every tag that would be deleted first check if it exists in the map, if it doesn't add a new key

--- a/cmd/acr/purge.go
+++ b/cmd/acr/purge.go
@@ -42,6 +42,7 @@ const (
 
 	defaultNumWorkers       = 6
 	manifestListContentType = "application/vnd.docker.distribution.manifest.list.v2+json"
+	linkHeader              = "Link"
 )
 
 // purgeParameters defines the parameters that the purge command uses (including the registry name, username and password).
@@ -167,31 +168,35 @@ func purgeTags(ctx context.Context, acrClient api.AcrCLIClientInterface, loginUR
 		return -1, err
 	}
 	lastTag := ""
-	tagsToDelete, lastTag, err := getTagsToDelete(ctx, acrClient, repoName, tagRegex, timeToCompare, "")
-	if err != nil {
-		return -1, err
-	}
+
 	// GetTagsToDelete will return an empty lastTag when there are no more tags.
-	for len(lastTag) > 0 {
-		for _, tag := range *tagsToDelete {
-			wg.Add(1)
-			// The purge job is queued, after a purge worker picks it up the tag will be deleted.
-			worker.QueuePurgeTag(loginURL, repoName, *tag.Name, *tag.Digest)
-			deletedTagsCount++
-		}
-		// To not overflow the error channel capacity the purgeTags function waits for a whole block of
-		// 100 jobs to be finished before continuing.
-		wg.Wait()
-		for len(worker.ErrorChannel) > 0 {
-			wErr := <-worker.ErrorChannel
-			if wErr.Error != nil {
-				return -1, wErr.Error
-			}
-		}
-		tagsToDelete, lastTag, err = getTagsToDelete(ctx, acrClient, repoName, tagRegex, timeToCompare, lastTag)
+	for {
+		tagsToDelete, newLastTag, err := getTagsToDelete(ctx, acrClient, repoName, tagRegex, timeToCompare, lastTag)
+		lastTag = newLastTag
 		if err != nil {
 			return -1, err
 		}
+		if tagsToDelete != nil {
+			for _, tag := range *tagsToDelete {
+				wg.Add(1)
+				// The purge job is queued, after a purge worker picks it up the tag will be deleted.
+				worker.QueuePurgeTag(loginURL, repoName, *tag.Name, *tag.Digest)
+				deletedTagsCount++
+			}
+			// To not overflow the error channel capacity the purgeTags function waits for a whole block of
+			// 100 jobs to be finished before continuing.
+			wg.Wait()
+			for len(worker.ErrorChannel) > 0 {
+				wErr := <-worker.ErrorChannel
+				if wErr.Error != nil {
+					return -1, wErr.Error
+				}
+			}
+		}
+		if len(lastTag) == 0 {
+			break
+		}
+
 	}
 	return deletedTagsCount, nil
 }
@@ -274,12 +279,37 @@ func getTagsToDelete(ctx context.Context,
 				tagsToDelete = append(tagsToDelete, tag)
 			}
 		}
-		// The lastTag is updated to keep the for loop going.
-		newLastTag = *tags[len(tags)-1].Name
+		newLastTag = getLastTagFromResponse(resultTags)
 		return &tagsToDelete, newLastTag, nil
 	}
 	// In case there are no more tags return empty string as lastTag so that the purgeTags function stops
 	return nil, "", nil
+}
+
+func getLastTagFromResponse(resultTags *acr.RepositoryTagsType) string {
+	newLastTag := ""
+	// The lastTag is updated to keep the for loop going.
+	if resultTags.Header != nil {
+		link := resultTags.Header.Get(linkHeader)
+		if len(link) > 0 {
+			queryString := strings.Split(link, "?")
+			if len(queryString) > 1 {
+				stripRel := strings.Split(queryString[1], ";")
+
+				queryParams := strings.Split(stripRel[0], "&")
+
+				for _, queryParam := range queryParams {
+					lastParam := strings.Split(queryParam, "last=")
+					if len(lastParam) > 1 {
+						newLastTag = lastParam[1]
+					}
+				}
+
+			}
+
+		}
+	}
+	return newLastTag
 }
 
 // purgeDanglingManifests deletes all manifests that do not have any tags associated with them.
@@ -400,26 +430,29 @@ func dryRunPurge(ctx context.Context, acrClient api.AcrCLIClientInterface, login
 		return -1, -1, err
 	}
 	lastTag := ""
-	tagsToDelete, lastTag, err := getTagsToDelete(ctx, acrClient, repoName, regex, timeToCompare, "")
-	if err != nil {
-		return -1, -1, err
-	}
 	// The loop to get the deleted tags follows the same logic as the one in the purgeTags function
-	for len(lastTag) > 0 {
-		for _, tag := range *tagsToDelete {
-			// For every tag that would be deleted first check if it exists in the map, if it doesn't add a new key
-			// with value 1 and if it does just add 1 to the existent value.
-			if _, exists := deletedTags[*tag.Digest]; exists {
-				deletedTags[*tag.Digest]++
-			} else {
-				deletedTags[*tag.Digest] = 1
-			}
-			fmt.Printf("%s/%s:%s\n", loginURL, repoName, *tag.Name)
-			deletedTagsCount++
-		}
-		tagsToDelete, lastTag, err = getTagsToDelete(ctx, acrClient, repoName, regex, timeToCompare, lastTag)
+	for {
+		tagsToDelete, newLastTag, err := getTagsToDelete(ctx, acrClient, repoName, regex, timeToCompare, lastTag)
+		lastTag = newLastTag
 		if err != nil {
 			return -1, -1, err
+		}
+
+		if tagsToDelete != nil {
+			for _, tag := range *tagsToDelete {
+				// For every tag that would be deleted first check if it exists in the map, if it doesn't add a new key
+				// with value 1 and if it does just add 1 to the existent value.
+				if _, exists := deletedTags[*tag.Digest]; exists {
+					deletedTags[*tag.Digest]++
+				} else {
+					deletedTags[*tag.Digest] = 1
+				}
+				fmt.Printf("%s/%s:%s\n", loginURL, repoName, *tag.Name)
+				deletedTagsCount++
+			}
+		}
+		if len(lastTag) == 0 {
+			break
 		}
 	}
 	if untagged {

--- a/cmd/acr/purge.go
+++ b/cmd/acr/purge.go
@@ -300,7 +300,8 @@ func getLastTagFromResponse(resultTags *acr.RepositoryTagsType) string {
 	if len(queryString) <= 1 {
 		return ""
 	}
-	vals, err := url.ParseQuery(queryString[1])
+	queryStringToParse := strings.Split(queryString[1], ">")
+	vals, err := url.ParseQuery(queryStringToParse[0])
 	if err != nil {
 		return ""
 	}

--- a/cmd/acr/purge.go
+++ b/cmd/acr/purge.go
@@ -428,11 +428,10 @@ func dryRunPurge(ctx context.Context, acrClient api.AcrCLIClientInterface, login
 	// The loop to get the deleted tags follows the same logic as the one in the purgeTags function
 	for {
 		tagsToDelete, newLastTag, err := getTagsToDelete(ctx, acrClient, repoName, regex, timeToCompare, lastTag)
-		lastTag = newLastTag
 		if err != nil {
 			return -1, -1, err
 		}
-
+        lastTag = newLastTag
 		if tagsToDelete != nil {
 			for _, tag := range *tagsToDelete {
 				// For every tag that would be deleted first check if it exists in the map, if it doesn't add a new key

--- a/cmd/acr/purge_test.go
+++ b/cmd/acr/purge_test.go
@@ -709,7 +709,7 @@ var (
 		Response: autorest.Response{
 			Response: &http.Response{
 				StatusCode: 200,
-				Header:     http.Header{linkHeader: {"/acr/v1/&testRepo/_tags?last=123%26latest&n=3&orderby=timedesc rel=\"next\""}},
+				Header:     http.Header{linkHeader: {"/acr/v1/&testRepo/_tags?n=3&orderby=timedesc&last=123%26latest; rel=\"next\""}},
 			},
 		},
 		Registry:  &testLoginURL,

--- a/cmd/acr/purge_test.go
+++ b/cmd/acr/purge_test.go
@@ -47,7 +47,6 @@ func TestPurgeTags(t *testing.T) {
 		assert := assert.New(t)
 		mockClient := &mocks.AcrCLIClientInterface{}
 		mockClient.On("GetAcrTags", testCtx, testRepo, "", "").Return(OneTagResult, nil).Once()
-		mockClient.On("GetAcrTags", testCtx, testRepo, "", "latest").Return(EmptyListTagsResult, nil).Once()
 		deletedTags, err := purgeTags(testCtx, mockClient, testLoginURL, testRepo, "1d", "[\\s\\S]*")
 		assert.Equal(0, deletedTags, "Number of deleted elements should be 0")
 		assert.Equal(nil, err, "Error should be nil")
@@ -59,7 +58,6 @@ func TestPurgeTags(t *testing.T) {
 		assert := assert.New(t)
 		mockClient := &mocks.AcrCLIClientInterface{}
 		mockClient.On("GetAcrTags", testCtx, testRepo, "", "").Return(OneTagResult, nil).Once()
-		mockClient.On("GetAcrTags", testCtx, testRepo, "", "latest").Return(EmptyListTagsResult, nil).Once()
 		deletedTags, err := purgeTags(testCtx, mockClient, testLoginURL, testRepo, "0m", "^hello.*")
 		assert.Equal(0, deletedTags, "Number of deleted elements should be 0")
 		assert.Equal(nil, err, "Error should be nil")
@@ -98,7 +96,7 @@ func TestPurgeTags(t *testing.T) {
 	t.Run("GetAcrTagsErrorMultiplePageTest", func(t *testing.T) {
 		assert := assert.New(t)
 		mockClient := &mocks.AcrCLIClientInterface{}
-		mockClient.On("GetAcrTags", testCtx, testRepo, "", "").Return(OneTagResult, nil).Once()
+		mockClient.On("GetAcrTags", testCtx, testRepo, "", "").Return(OneTagResultWithNext, nil).Once()
 		mockClient.On("GetAcrTags", testCtx, testRepo, "", "latest").Return(nil, errors.New("unauthorized")).Once()
 		deletedTags, err := purgeTags(testCtx, mockClient, testLoginURL, testRepo, "1d", "[\\s\\S]*")
 		assert.Equal(-1, deletedTags, "Number of deleted elements should be -1")
@@ -111,7 +109,6 @@ func TestPurgeTags(t *testing.T) {
 		assert := assert.New(t)
 		mockClient := &mocks.AcrCLIClientInterface{}
 		mockClient.On("GetAcrTags", testCtx, testRepo, "", "").Return(DeleteDisabledOneTagResult, nil).Once()
-		mockClient.On("GetAcrTags", testCtx, testRepo, "", "latest").Return(EmptyListTagsResult, nil).Once()
 		deletedTags, err := purgeTags(testCtx, mockClient, testLoginURL, testRepo, "0m", "^la.*")
 		assert.Equal(0, deletedTags, "Number of deleted elements should be 0")
 		assert.Equal(nil, err, "Error should be nil")
@@ -134,7 +131,6 @@ func TestPurgeTags(t *testing.T) {
 		mockClient := mocks.AcrCLIClientInterface{}
 		worker.StartDispatcher(testCtx, &wg, &mockClient, 6)
 		mockClient.On("GetAcrTags", testCtx, testRepo, "", "").Return(OneTagResult, nil).Once()
-		mockClient.On("GetAcrTags", testCtx, testRepo, "", "latest").Return(EmptyListTagsResult, nil).Once()
 		mockClient.On("DeleteAcrTag", testCtx, testRepo, "latest").Return(&deletedResponse, nil).Once()
 		deletedTags, err := purgeTags(testCtx, &mockClient, testLoginURL, testRepo, "0m", "^la.*")
 		worker.StopDispatcher()
@@ -148,9 +144,8 @@ func TestPurgeTags(t *testing.T) {
 		assert := assert.New(t)
 		mockClient := mocks.AcrCLIClientInterface{}
 		worker.StartDispatcher(testCtx, &wg, &mockClient, 6)
-		mockClient.On("GetAcrTags", testCtx, testRepo, "", "").Return(OneTagResult, nil).Once()
+		mockClient.On("GetAcrTags", testCtx, testRepo, "", "").Return(OneTagResultWithNext, nil).Once()
 		mockClient.On("GetAcrTags", testCtx, testRepo, "", "latest").Return(FourTagsResult, nil).Once()
-		mockClient.On("GetAcrTags", testCtx, testRepo, "", "v4").Return(EmptyListTagsResult, nil).Once()
 		mockClient.On("DeleteAcrTag", testCtx, testRepo, "latest").Return(&deletedResponse, nil).Once()
 		mockClient.On("DeleteAcrTag", testCtx, testRepo, "v1").Return(&deletedResponse, nil).Once()
 		mockClient.On("DeleteAcrTag", testCtx, testRepo, "v2").Return(&deletedResponse, nil).Once()
@@ -168,7 +163,6 @@ func TestPurgeTags(t *testing.T) {
 		mockClient := mocks.AcrCLIClientInterface{}
 		worker.StartDispatcher(testCtx, &wg, &mockClient, 6)
 		mockClient.On("GetAcrTags", testCtx, testRepo, "", "").Return(OneTagResult, nil).Once()
-		mockClient.On("GetAcrTags", testCtx, testRepo, "", "latest").Return(nil, nil).Once()
 		mockClient.On("DeleteAcrTag", testCtx, testRepo, "latest").Return(&notFoundResponse, errors.New("not found")).Once()
 		deletedTags, err := purgeTags(testCtx, &mockClient, testLoginURL, testRepo, "0m", "^la.*")
 		worker.StopDispatcher()
@@ -387,7 +381,6 @@ func TestDryRun(t *testing.T) {
 		assert := assert.New(t)
 		mockClient := &mocks.AcrCLIClientInterface{}
 		mockClient.On("GetAcrTags", testCtx, testRepo, "", "").Return(FourTagsResult, nil).Once()
-		mockClient.On("GetAcrTags", testCtx, testRepo, "", "v4").Return(EmptyListTagsResult, nil).Once()
 		deletedTags, deletedManifests, err := dryRunPurge(testCtx, mockClient, testLoginURL, testRepo, "0m", "[\\s\\S]*", false)
 		assert.Equal(4, deletedTags, "Number of deleted elements should be 4")
 		assert.Equal(0, deletedManifests, "Number of deleted elements should be 0")
@@ -409,8 +402,7 @@ func TestDryRun(t *testing.T) {
 	t.Run("GetAcrTagsError2Test", func(t *testing.T) {
 		assert := assert.New(t)
 		mockClient := &mocks.AcrCLIClientInterface{}
-		mockClient.On("GetAcrTags", testCtx, testRepo, "", "").Return(FourTagsResult, nil).Once()
-		mockClient.On("GetAcrTags", testCtx, testRepo, "", "v4").Return(nil, errors.New("error fetching tags")).Once()
+		mockClient.On("GetAcrTags", testCtx, testRepo, "", "").Return(nil, errors.New("error fetching tags")).Once()
 		deletedTags, deletedManifests, err := dryRunPurge(testCtx, mockClient, testLoginURL, testRepo, "0m", "[\\s\\S]*", false)
 		assert.Equal(-1, deletedTags, "Number of deleted elements should be -1")
 		assert.Equal(-1, deletedManifests, "Number of deleted elements should be -1")
@@ -446,7 +438,7 @@ func TestDryRun(t *testing.T) {
 		assert := assert.New(t)
 		mockClient := &mocks.AcrCLIClientInterface{}
 		mockClient.On("GetAcrTags", testCtx, testRepo, "", "").Return(FourTagsResult, nil).Twice()
-		mockClient.On("GetAcrTags", testCtx, testRepo, "", "v4").Return(EmptyListTagsResult, nil).Twice()
+		mockClient.On("GetAcrTags", testCtx, testRepo, "", "v4").Return(EmptyListTagsResult, nil).Once()
 		mockClient.On("GetAcrManifests", testCtx, testRepo, "", "").Return(singleMultiArchWithTagsResult, nil).Once()
 		mockClient.On("GetManifest", testCtx, testRepo, "sha:356").Return(nil, errors.New("error getting manifest")).Once()
 		deletedTags, deletedManifests, err := dryRunPurge(testCtx, mockClient, testLoginURL, testRepo, "0m", "^lat.*", true)
@@ -460,7 +452,7 @@ func TestDryRun(t *testing.T) {
 		assert := assert.New(t)
 		mockClient := &mocks.AcrCLIClientInterface{}
 		mockClient.On("GetAcrTags", testCtx, testRepo, "", "").Return(FourTagsResult, nil).Twice()
-		mockClient.On("GetAcrTags", testCtx, testRepo, "", "v4").Return(EmptyListTagsResult, nil).Twice()
+		mockClient.On("GetAcrTags", testCtx, testRepo, "", "v4").Return(EmptyListTagsResult, nil).Once()
 		mockClient.On("GetAcrManifests", testCtx, testRepo, "", "").Return(singleMultiArchWithTagsResult, nil).Once()
 		mockClient.On("GetManifest", testCtx, testRepo, "sha:356").Return([]byte("invalid json"), nil).Once()
 		deletedTags, deletedManifests, err := dryRunPurge(testCtx, mockClient, testLoginURL, testRepo, "0m", "^lat.*", true)
@@ -473,9 +465,7 @@ func TestDryRun(t *testing.T) {
 	t.Run("MultiArchGetAcrTagsErrorTest", func(t *testing.T) {
 		assert := assert.New(t)
 		mockClient := &mocks.AcrCLIClientInterface{}
-		mockClient.On("GetAcrTags", testCtx, testRepo, "", "").Return(FourTagsResult, nil).Once()
-		mockClient.On("GetAcrTags", testCtx, testRepo, "", "").Return(FourTagsResult, nil).Once()
-		mockClient.On("GetAcrTags", testCtx, testRepo, "", "v4").Return(EmptyListTagsResult, nil).Once()
+		mockClient.On("GetAcrTags", testCtx, testRepo, "", "").Return(FourTagsResult, nil).Twice()
 		mockClient.On("GetAcrTags", testCtx, testRepo, "", "v4").Return(nil, errors.New("error fetching tags")).Once()
 		deletedTags, deletedManifests, err := dryRunPurge(testCtx, mockClient, testLoginURL, testRepo, "0m", "^lat.*", true)
 		assert.Equal(-1, deletedTags, "Number of deleted elements should be -1")
@@ -487,9 +477,7 @@ func TestDryRun(t *testing.T) {
 	t.Run("MultiArchGetAcrTagsError2Test", func(t *testing.T) {
 		assert := assert.New(t)
 		mockClient := &mocks.AcrCLIClientInterface{}
-		mockClient.On("GetAcrTags", testCtx, testRepo, "", "").Return(FourTagsResult, nil).Once()
-		mockClient.On("GetAcrTags", testCtx, testRepo, "", "").Return(FourTagsResult, nil).Once()
-		mockClient.On("GetAcrTags", testCtx, testRepo, "", "v4").Return(EmptyListTagsResult, nil).Once()
+		mockClient.On("GetAcrTags", testCtx, testRepo, "", "").Return(FourTagsResult, nil).Twice()
 		mockClient.On("GetAcrTags", testCtx, testRepo, "", "v4").Return(EmptyListTagsResult, nil).Once()
 		mockClient.On("GetAcrManifests", testCtx, testRepo, "", "").Return(singleMultiArchWithTagsResult, nil).Once()
 		mockClient.On("GetManifest", testCtx, testRepo, "sha:356").Return(multiArchBytes, nil).Once()
@@ -506,7 +494,7 @@ func TestDryRun(t *testing.T) {
 		assert := assert.New(t)
 		mockClient := &mocks.AcrCLIClientInterface{}
 		mockClient.On("GetAcrTags", testCtx, testRepo, "", "").Return(FourTagsResult, nil).Twice()
-		mockClient.On("GetAcrTags", testCtx, testRepo, "", "v4").Return(EmptyListTagsResult, nil).Twice()
+		mockClient.On("GetAcrTags", testCtx, testRepo, "", "v4").Return(EmptyListTagsResult, nil).Once()
 		mockClient.On("GetAcrManifests", testCtx, testRepo, "", "").Return(singleMultiArchWithTagsResult, nil).Once()
 		mockClient.On("GetManifest", testCtx, testRepo, "sha:356").Return(multiArchBytes, nil).Once()
 		mockClient.On("GetAcrManifests", testCtx, testRepo, "", "sha:356").Return(doubleManifestV2WithoutTagsResult, nil).Once()
@@ -547,6 +535,49 @@ func TestGetRepositoryAndTagRegex(t *testing.T) {
 		assert.Equal("", repository)
 		assert.Equal("", filter)
 		assert.NotEqual(nil, err, "Error should not be nil")
+	})
+}
+
+// TestGetLastTagFromResponse returns the last tag from response.
+func TestGetLastTagFromResponse(t *testing.T) {
+
+	t.Run("ReturnEmptyForNoHeaders", func(t *testing.T) {
+		assert := assert.New(t)
+		lastTag := getLastTagFromResponse(OneTagResult)
+		assert.Equal("", lastTag)
+	})
+
+	t.Run("ReturnEmptyForNoLinkHeaders", func(t *testing.T) {
+		assert := assert.New(t)
+		ResultWithNoLinkHeader := &acr.RepositoryTagsType{
+			Response: autorest.Response{
+				Response: &http.Response{
+					StatusCode: 200,
+					Header:     http.Header{"testHeader": {"Test Values"}},
+				},
+			},
+		}
+		lastTag := getLastTagFromResponse(ResultWithNoLinkHeader)
+		assert.Equal("", lastTag)
+	})
+
+	t.Run("ReturnEmptyForNoQueryString", func(t *testing.T) {
+		assert := assert.New(t)
+		ResultWithNoQuery := &acr.RepositoryTagsType{
+			Response: autorest.Response{
+				Response: &http.Response{
+					StatusCode: 200,
+					Header:     http.Header{linkHeader: {"/acr/v1/&testRepo/_tags"}}},
+			},
+		}
+		lastTag := getLastTagFromResponse(ResultWithNoQuery)
+		assert.Equal("", lastTag)
+	})
+
+	t.Run("ReturnLastTagFromHeader", func(t *testing.T) {
+		assert := assert.New(t)
+		lastTag := getLastTagFromResponse(OneTagResultWithNext)
+		assert.Equal("latest", lastTag)
 	})
 }
 
@@ -606,6 +637,30 @@ var (
 	invalidLastUpdateTime = "date"
 
 	OneTagResult = &acr.RepositoryTagsType{
+		Response: autorest.Response{
+			Response: &http.Response{
+				StatusCode: 200,
+			},
+		},
+		Registry:  &testLoginURL,
+		ImageName: &testRepo,
+		TagsAttributes: &[]acr.TagAttributesBase{
+			{
+				Name:                 &tagName,
+				LastUpdateTime:       &lastUpdateTime,
+				ChangeableAttributes: &acr.ChangeableAttributes{DeleteEnabled: &deleteEnabled},
+				Digest:               &digest,
+			},
+		},
+	}
+
+	OneTagResultWithNext = &acr.RepositoryTagsType{
+		Response: autorest.Response{
+			Response: &http.Response{
+				StatusCode: 200,
+				Header:     http.Header{linkHeader: {"/acr/v1/&testRepo/_tags?last=latest&n=3&orderby=timedesc"}},
+			},
+		},
 		Registry:  &testLoginURL,
 		ImageName: &testRepo,
 		TagsAttributes: &[]acr.TagAttributesBase{
@@ -619,6 +674,11 @@ var (
 	}
 
 	InvalidDateOneTagResult = &acr.RepositoryTagsType{
+		Response: autorest.Response{
+			Response: &http.Response{
+				StatusCode: 200,
+			},
+		},
 		Registry:  &testLoginURL,
 		ImageName: &testRepo,
 		TagsAttributes: &[]acr.TagAttributesBase{
@@ -632,6 +692,11 @@ var (
 	}
 
 	DeleteDisabledOneTagResult = &acr.RepositoryTagsType{
+		Response: autorest.Response{
+			Response: &http.Response{
+				StatusCode: 200,
+			},
+		},
 		Registry:  &testLoginURL,
 		ImageName: &testRepo,
 		TagsAttributes: &[]acr.TagAttributesBase{
@@ -649,6 +714,11 @@ var (
 	tagName4 = "v4"
 
 	FourTagsResult = &acr.RepositoryTagsType{
+		Response: autorest.Response{
+			Response: &http.Response{
+				StatusCode: 200,
+			},
+		},
 		Registry:  &testLoginURL,
 		ImageName: &testRepo,
 		TagsAttributes: &[]acr.TagAttributesBase{{

--- a/cmd/acr/purge_test.go
+++ b/cmd/acr/purge_test.go
@@ -671,7 +671,7 @@ var (
 		Response: autorest.Response{
 			Response: &http.Response{
 				StatusCode: 200,
-				Header:     http.Header{linkHeader: {"/acr/v1/&testRepo/_tags?last=latest&n=3&orderby=timedesc rel=\"next\""}},
+				Header:     http.Header{linkHeader: {"</acr/v1/&testRepo/_tags?last=latest&n=3&orderby=timedesc>; rel=\"next\""}},
 			},
 		},
 		Registry:  &testLoginURL,
@@ -690,7 +690,7 @@ var (
 		Response: autorest.Response{
 			Response: &http.Response{
 				StatusCode: 200,
-				Header:     http.Header{linkHeader: {"/acr/v1/&testRepo/_tags?last=123%26latest&n=3&orderby=timedesc rel=\"next\""}},
+				Header:     http.Header{linkHeader: {"</acr/v1/&testRepo/_tags?last=123%26latest&n=3&orderby=>; rel=\"next\""}},
 			},
 		},
 		Registry:  &testLoginURL,
@@ -709,7 +709,7 @@ var (
 		Response: autorest.Response{
 			Response: &http.Response{
 				StatusCode: 200,
-				Header:     http.Header{linkHeader: {"/acr/v1/&testRepo/_tags?n=3&orderby=timedesc&last=123%26latest; rel=\"next\""}},
+				Header:     http.Header{linkHeader: {"</acr/v1/&testRepo/_tags?n=3&orderby=timedesc&last=123%26latest>; rel=\"next\""}},
 			},
 		},
 		Registry:  &testLoginURL,

--- a/cmd/acr/purge_test.go
+++ b/cmd/acr/purge_test.go
@@ -579,6 +579,19 @@ func TestGetLastTagFromResponse(t *testing.T) {
 		lastTag := getLastTagFromResponse(OneTagResultWithNext)
 		assert.Equal("latest", lastTag)
 	})
+
+	t.Run("ReturnLastWithAmpersand", func(t *testing.T) {
+		assert := assert.New(t)
+		lastTag := getLastTagFromResponse(OneTagResultWithAmpersand)
+		assert.Equal("123&latest", lastTag)
+	})
+
+	t.Run("ReturnLastWhenQueryEndingWithLast", func(t *testing.T) {
+		assert := assert.New(t)
+		lastTag := getLastTagFromResponse(OneTagResultQueryEndingWithLast)
+		assert.Equal("123&latest", lastTag)
+	})
+
 }
 
 // TestParseDuration returns an extended duration from a string.
@@ -658,7 +671,45 @@ var (
 		Response: autorest.Response{
 			Response: &http.Response{
 				StatusCode: 200,
-				Header:     http.Header{linkHeader: {"/acr/v1/&testRepo/_tags?last=latest&n=3&orderby=timedesc"}},
+				Header:     http.Header{linkHeader: {"/acr/v1/&testRepo/_tags?last=latest&n=3&orderby=timedesc rel=\"next\""}},
+			},
+		},
+		Registry:  &testLoginURL,
+		ImageName: &testRepo,
+		TagsAttributes: &[]acr.TagAttributesBase{
+			{
+				Name:                 &tagName,
+				LastUpdateTime:       &lastUpdateTime,
+				ChangeableAttributes: &acr.ChangeableAttributes{DeleteEnabled: &deleteEnabled},
+				Digest:               &digest,
+			},
+		},
+	}
+
+	OneTagResultWithAmpersand = &acr.RepositoryTagsType{
+		Response: autorest.Response{
+			Response: &http.Response{
+				StatusCode: 200,
+				Header:     http.Header{linkHeader: {"/acr/v1/&testRepo/_tags?last=123%26latest&n=3&orderby=timedesc rel=\"next\""}},
+			},
+		},
+		Registry:  &testLoginURL,
+		ImageName: &testRepo,
+		TagsAttributes: &[]acr.TagAttributesBase{
+			{
+				Name:                 &tagName,
+				LastUpdateTime:       &lastUpdateTime,
+				ChangeableAttributes: &acr.ChangeableAttributes{DeleteEnabled: &deleteEnabled},
+				Digest:               &digest,
+			},
+		},
+	}
+
+	OneTagResultQueryEndingWithLast = &acr.RepositoryTagsType{
+		Response: autorest.Response{
+			Response: &http.Response{
+				StatusCode: 200,
+				Header:     http.Header{linkHeader: {"/acr/v1/&testRepo/_tags?last=123%26latest&n=3&orderby=timedesc rel=\"next\""}},
 			},
 		},
 		Registry:  &testLoginURL,


### PR DESCRIPTION
- Refactoring code to get lastTag.
- Current logic fails when using orderBy
- See https://github.com/Azure/acr-cli/pull/72#issuecomment-664201313