### PR TITLE
Upgrade from dgrijalva/jwt-go to golang-jwt/jwt/v4

### DIFF
--- a/cmd/acr/purge_test.go
+++ b/cmd/acr/purge_test.go
@@ -650,8 +650,8 @@ func TestParseDuration(t *testing.T) {
 		{"1d1h3m", -25*time.Hour - 3*time.Minute, nil},
 		{"3d", -3 * 24 * time.Hour, nil},
 		{"", 0, io.EOF},
-		{"15p", 0, errors.New("time: unknown unit p in duration 15p")},
-		{"15", 0 * time.Minute, errors.New("time: missing unit in duration 15")},
+		{"15p", 0, errors.New("time: unknown unit \"p\" in duration \"15p\"")},
+		{"15", 0 * time.Minute, errors.New("time: missing unit in duration \"15\"")},
 	}
 	assert := assert.New(t)
 	for _, table := range tables {

--- a/cmd/api/acrsdk.go
+++ b/cmd/api/acrsdk.go
@@ -15,7 +15,7 @@ import (
 	dockerAuth "github.com/Azure/acr-cli/auth/docker"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/adal"
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/pkg/errors"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/Azure/go-autorest/autorest/adal v0.1.0
 	github.com/Azure/go-autorest/tracing v0.1.0
 	github.com/containerd/containerd v1.3.3 // indirect
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/docker/cli v0.0.0-20190506213505-d88565df0c2d
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v1.14.0-0.20190131205458-8a43b7bb99cd
@@ -17,6 +16,7 @@ require (
 	github.com/docker/go-metrics v0.0.0-20181218153428-b84716841b82 // indirect
 	github.com/docker/go-units v0.3.3 // indirect
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
+	github.com/golang-jwt/jwt/v4 v4.1.0
 	github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c // indirect
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0 h1:xU6/SpYbvkNYiptHJYEDRseDLvYE7wSqhYYNy0QSUzI=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
+github.com/golang-jwt/jwt/v4 v4.1.0 h1:XUgk2Ex5veyVFVeLm0xhusUTQybEbexJXrvPNOKkSY0=
+github.com/golang-jwt/jwt/v4 v4.1.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=


### PR DESCRIPTION
**Purpose of the PR**

- This PR upgrades from dgrijalva/jwt-go to golang-jwt/jwt/v4 since dgrijalva/jwt-go was marked as vulnerable
