### PR TITLE
Feature: list repos with size

### DIFF
--- a/cmd/acr/repository.go
+++ b/cmd/acr/repository.go
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/Azure/acr-cli/cmd/api"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/Azure/acr-cli/cmd/worker"
+)
+
+const (
+	newRepositoryCmdLongMessage       = `acr repository: list all repositories with size.`
+)
+
+// Besides the registry name and authentication information only the repository is needed.
+type RepositoryParameters struct {
+	*rootParameters
+	concurrency int
+}
+
+// The tag command can be used to either list tags or delete tags inside a repository.
+// that can be done with the tag list and tag delete commands respectively.
+func newRepositoryCmd(out io.Writer, rootParams *rootParameters) *cobra.Command {
+	RepositoryParams := RepositoryParameters{rootParameters: rootParams}
+	cmd := &cobra.Command{
+		Use:   "repo",
+		Short: "Manage repositories",
+		Long:  newRepositoryCmdLongMessage,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.Help()
+			return nil
+		},
+	}
+
+	listCmd := newListCmd(out, &RepositoryParams)
+
+	cmd.AddCommand(
+		listCmd,
+	)
+
+	cmd.Flags().IntVar(&RepositoryParams.concurrency, "concurrency", defaultPoolSize, concurrencyDescription)
+
+	return cmd
+}
+
+// newListCmd creates list command, it does not need any aditional parameters.
+// The registry interaction is done through the listRepos method
+func newListCmd(out io.Writer, RepositoryParams *RepositoryParameters) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List repositories",
+		Long:  newRepositoryCmdLongMessage,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			registryName, err := RepositoryParams.GetRegistryName()
+			if err != nil {
+				return err
+			}
+			loginURL := api.LoginURL(registryName)
+			// An acrClient is created to make the http requests to the registry.
+			acrClient, err := api.GetAcrCLIClientWithAuth(loginURL, RepositoryParams.username, RepositoryParams.password, RepositoryParams.configs)
+			if err != nil {
+				return err
+			}
+			ctx := context.Background()
+			err = listRepos(ctx, acrClient, loginURL, RepositoryParams.concurrency)
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
+// listRepos uses a worker pool to crawl through all repos and calculate its size by summing up its underlying manifests
+func listRepos(ctx context.Context, acrClient api.AcrCLIClientInterface, loginURL string, poolSize int) error {
+	lastRepo := ""
+	var maxItems int32 = 100
+
+	Repos, err := acrClient.GetAcrRepositories(ctx, lastRepo, &maxItems)
+	if err != nil {
+		return errors.Wrap(err, "failed repositories")
+	}
+
+	fmt.Printf("Listing repositories:\n")
+	lister := worker.NewLister(poolSize, acrClient, loginURL)
+	listErr := lister.ListRepos(ctx, Repos)
+	if listErr != nil {
+		return errors.Wrap(err, "failed repositories")
+	}
+	return nil
+}

--- a/cmd/acr/root.go
+++ b/cmd/acr/root.go
@@ -40,6 +40,7 @@ To start working with the CLI, run acr --help`,
 		newLogoutCmd(out),
 		newTagCmd(out, &rootParams),
 		newManifestCmd(out, &rootParams),
+		newRepositoryCmd(out, &rootParams),
 	)
 	cmd.PersistentFlags().StringVarP(&rootParams.registryName, "registry", "r", "", "Registry name")
 	cmd.PersistentFlags().StringVarP(&rootParams.username, "username", "u", "", "Registry username")

--- a/cmd/api/acrsdk.go
+++ b/cmd/api/acrsdk.go
@@ -193,6 +193,21 @@ func (c *AcrCLIClient) GetAcrTags(ctx context.Context, repoName string, orderBy 
 	return &tags, nil
 }
 
+// GetAcrRepositories list the tags of a repository with their attributes.
+func (c *AcrCLIClient) GetAcrRepositories(ctx context.Context, last string, n *int32) (*acrapi.Repositories, error) {
+	if c.isExpired() {
+		if err := refreshAcrCLIClientToken(ctx, c); err != nil {
+			return nil, err
+		}
+	}
+	repos, err := c.AutorestClient.GetAcrRepositories(ctx, last, n)
+	if err != nil {
+		// tags might contain information such as status codes, so it a pointer to it is returned instead of nil.
+		return &repos, err
+	}
+	return &repos, nil
+}
+
 // DeleteAcrTag deletes the tag by reference.
 func (c *AcrCLIClient) DeleteAcrTag(ctx context.Context, repoName string, reference string) (*autorest.Response, error) {
 	if c.isExpired() {
@@ -283,4 +298,5 @@ type AcrCLIClientInterface interface {
 	GetAcrManifests(ctx context.Context, repoName string, orderBy string, last string) (*acrapi.Manifests, error)
 	DeleteManifest(ctx context.Context, repoName string, reference string) (*autorest.Response, error)
 	GetManifest(ctx context.Context, repoName string, reference string) ([]byte, error)
+	GetAcrRepositories(ctx context.Context, last string, n *int32) (*acrapi.Repositories, error)
 }

--- a/cmd/worker/lister.go
+++ b/cmd/worker/lister.go
@@ -1,0 +1,67 @@
+package worker
+
+import (
+	"context"
+	"sync"
+
+	"github.com/Azure/acr-cli/acr"
+	"github.com/Azure/acr-cli/cmd/api"
+)
+
+type Lister struct {
+	pool      *pool
+	acrClient api.AcrCLIClientInterface
+	loginURL  string
+}
+
+func NewLister(poolSize int, acrClient api.AcrCLIClientInterface, loginURL string) *Lister {
+	return &Lister{
+		pool:      newPool(poolSize),
+		acrClient: acrClient,
+		loginURL:  loginURL,
+	}
+}
+
+func (p *Lister) process(ctx context.Context, jobs *[]Job) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	var succ int64
+	errChan := make(chan error)
+
+	// Start jobs in worker pool.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for _, job := range *jobs {
+			p.pool.start(ctx, job, p.acrClient, errChan, &wg, &succ)
+		}
+	}()
+
+	// Wait for all jobs to finish.
+	go func() {
+		wg.Wait()
+		close(errChan)
+	}()
+
+	// If there are errors occurred during processing jobs, record the first error and cancel other jobs.
+	var firstErr error
+	for err := range errChan {
+		if firstErr == nil {
+			firstErr = err
+			cancel()
+		}
+	}
+
+	return firstErr
+}
+
+func (p *Lister) ListRepos(ctx context.Context, repos *acr.Repositories) error {
+	jobs := make([]Job, len(*repos.Names))
+	for i, name := range *repos.Names {
+		jobs[i] = newGetRepoSizeJob(p.loginURL, name)
+	}
+
+	return p.process(ctx, &jobs)
+}

--- a/cmd/worker/listjob.go
+++ b/cmd/worker/listjob.go
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package worker
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Azure/acr-cli/cmd/api"
+)
+
+type Job interface {
+	process(context.Context, api.AcrCLIClientInterface) error
+}
+
+type repoSizeJob struct {
+	loginURL    string
+	repoName    string
+	timeCreated time.Time
+}
+
+func newGetRepoSizeJob(loginURL string, repoName string) *repoSizeJob {
+	return &repoSizeJob{
+		loginURL: 	loginURL,
+		repoName:   repoName,
+	}
+}
+
+// process calls acrClient
+func (job *repoSizeJob) process(ctx context.Context, acrClient api.AcrCLIClientInterface) error {
+	var manifestSize int64 = 0
+	lastManifestDigest := ""
+
+	resultManifests, err := acrClient.GetAcrManifests(ctx, job.repoName, "", lastManifestDigest)
+	if err != nil {
+		return err
+	}
+
+	// A for loop is used because the GetAcrManifests method returns by default only 100 manifests and their attributes.
+	for resultManifests != nil && resultManifests.ManifestsAttributes != nil {
+		manifests := *resultManifests.ManifestsAttributes
+		for _, manifest := range manifests {
+			manifestSize += *manifest.ImageSize
+		}
+		// Since the GetAcrManifests supports pagination when supplied with the last digest that was returned the last manifest
+		// digest is saved, the manifest array contains at least one element because if it was empty the API would return
+		// a nil pointer instead of a pointer to a length 0 array.
+		lastManifestDigest = *manifests[len(manifests)-1].Digest
+
+		resultManifests, err = acrClient.GetAcrManifests(ctx, job.repoName, "", lastManifestDigest)
+		if err != nil {
+			return err
+		}
+	}
+
+	manifestSizeInGB := float64(manifestSize)/1024/1024/1024
+	fmt.Printf("%-50s%10.3f GB\n", job.repoName, manifestSizeInGB)
+
+	return err
+}


### PR DESCRIPTION
**Purpose of the PR**

- added possibility to list all repositories of a registry with its size, based on the underlying manifests
- implemented a worker pool to crawl through the repositories
- implemented pool limitation, defaults to amount of processor threads
- concurrency can be adjusted