### PR TITLE
added one message at the beginning of dryRunPurge

### DIFF
--- a/cmd/acr/purge.go
+++ b/cmd/acr/purge.go
@@ -103,6 +103,10 @@ func newPurgeCmd(out io.Writer, rootParams *rootParameters) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			// A clarification message for --dry-run.
+			if purgeParams.dryRun {
+				fmt.Println("DRY RUN: The following output shows what WOULD be deleted if the purge command was executed. Nothing is deleted.")
+			}
 			// In order to print a summary of the deleted tags/manifests the counters get updated everytime a repo is purged.
 			deletedTagsCount := 0
 			deletedManifestsCount := 0

--- a/cmd/acr/purge.go
+++ b/cmd/acr/purge.go
@@ -147,9 +147,13 @@ func newPurgeCmd(out io.Writer, rootParams *rootParameters) *cobra.Command {
 				}
 			}
 			// After all repos have been purged the summary is printed.
-			fmt.Printf("\nNumber of deleted tags: %d\n", deletedTagsCount)
-			fmt.Printf("Number of deleted manifests: %d\n", deletedManifestsCount)
-
+			if purgeParams.dryRun {
+				fmt.Printf("\nNumber of tags to be deleted: %d\n", deletedTagsCount)
+				fmt.Printf("Number of manifests to be deleted: %d\n", deletedManifestsCount)
+			} else {
+				fmt.Printf("\nNumber of deleted tags: %d\n", deletedTagsCount)
+				fmt.Printf("Number of deleted manifests: %d\n", deletedManifestsCount)
+			}
 			return nil
 		},
 	}
@@ -513,7 +517,7 @@ func dryRunPurge(ctx context.Context, acrClient api.AcrCLIClientInterface, login
 	// In order to keep track if a manifest would get deleted a map is defined that as a  key has the manifest
 	// digest and as the value the number of tags (referencing said manifests) that were deleted.
 	deletedTags := map[string]int{}
-	fmt.Printf("Deleting tags for repository: %s\n", repoName)
+	fmt.Printf("This repository would be deleted: %s\n", repoName)
 	agoDuration, err := parseDuration(ago)
 	if err != nil {
 		return -1, -1, err
@@ -549,7 +553,7 @@ func dryRunPurge(ctx context.Context, acrClient api.AcrCLIClientInterface, login
 		}
 	}
 	if untagged {
-		fmt.Printf("Deleting manifests for repository: %s\n", repoName)
+		fmt.Printf("Manifests for this repository would be deleted: %s\n", repoName)
 		// The countMap contains a map that for every digest contains how many tags are referencing it.
 		countMap, err := countTagsByManifest(ctx, acrClient, repoName)
 		if err != nil {


### PR DESCRIPTION
**Purpose of the PR**
#107 Improved the output message in dry run mode. Added one message making clear that nothing will be deleted, and changed the wording for dry run output.

Output after the change:
```
$ ./bin/acr purge \
--registry wxxfirstcontainerregistry.azurecr.io \
--filter "app:^hello.*" \
--ago 10d 

Number of deleted tags: 0
Number of deleted manifests: 0

$ ./bin/acr purge \
--registry wxxfirstcontainerregistry.azurecr.io \
--filter "app:^hello.*" \
--ago 10d \
--dry-run

DRY RUN: The following output shows what WOULD be deleted if the purge command was executed. Nothing is deleted.

Number of tags to be deleted: 0
Number of manifests to be deleted: 0
```