### PR TITLE
Change confusing dry-run message

### DIFF
--- a/cmd/acr/purge.go
+++ b/cmd/acr/purge.go
@@ -517,7 +517,7 @@ func dryRunPurge(ctx context.Context, acrClient api.AcrCLIClientInterface, login
 	// In order to keep track if a manifest would get deleted a map is defined that as a  key has the manifest
 	// digest and as the value the number of tags (referencing said manifests) that were deleted.
 	deletedTags := map[string]int{}
-	fmt.Printf("This repository would be deleted: %s\n", repoName)
+	fmt.Printf("Tags for this repository would be deleted: %s\n", repoName)
 	agoDuration, err := parseDuration(ago)
 	if err != nil {
 		return -1, -1, err


### PR DESCRIPTION
**Purpose of the PR**
- Changed confusing message in `acr purge` with --dry-run flag set

I found it confusing that the `acr purge` command with --dry-run flag set informs me that the whole repositories would be deleted rather than tags in the repository if I used the command without the flag set.  I believe that the message is now more informative and unambiguous.