### PR TITLE
fix: fallback to refresh token when loading from docker config file

### DIFF
--- a/cmd/api/acrsdk.go
+++ b/cmd/api/acrsdk.go
@@ -115,13 +115,18 @@ func GetAcrCLIClientWithAuth(loginURL string, username string, password string, 
 		}
 		username = cred.Username
 		password = cred.Password
+
+		// fallback to refresh token if it is available
+		if password == "" && cred.RefreshToken != "" {
+			password = cred.RefreshToken
+		}
 	}
 	// If the password is empty then the authentication failed.
 	if password == "" {
 		return nil, errors.New("unable to resolve authentication, missing identity token or password")
 	}
 	var acrClient AcrCLIClient
-	if username == "" {
+	if username == "" || username == "00000000-0000-0000-0000-000000000000" {
 		// If the username is empty an ACR refresh token was used.
 		var err error
 		acrClient, err = newAcrCLIClientWithBearerAuth(loginURL, password)


### PR DESCRIPTION
Signed-off-by: wangxiaoxuan273 <wangxiaoxuan119@gmail.com>

Fixes #127 

E2E result is successful. `az acr run --cmd "$registry/acr-cli purge --filter 'busybox:.*' --ago 1d --untagged --dry-run" --registry $registry /dev/null`
![image](https://user-images.githubusercontent.com/103478229/210772902-6aa1f37d-a1ce-47cf-bd6c-3169becd378b.png)
