### PR TITLE
fix: support oci image index

### DIFF
--- a/cmd/api/acrsdk.go
+++ b/cmd/api/acrsdk.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/golang-jwt/jwt/v4"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
 
@@ -26,8 +27,8 @@ const (
 	manifestTagFetchCount            = 100
 	manifestORASArtifactContentType  = "application/vnd.cncf.oras.artifact.manifest.v1+json"
 	manifestOCIArtifactContentType   = "application/vnd.oci.artifact.manifest.v1+json"
-	manifestOCIImageContentType      = "application/vnd.oci.image.manifest.v1+json"
-	manifestOCIImageIndexContentType = "application/vnd.oci.image.index.v1+json"
+	manifestOCIImageContentType      = v1.MediaTypeImageManifest
+	manifestOCIImageIndexContentType = v1.MediaTypeImageIndex
 	manifestImageContentType         = "application/vnd.docker.distribution.manifest.v2+json"
 	manifestListContentType          = "application/vnd.docker.distribution.manifest.list.v2+json"
 	manifestAcceptHeader             = "*/*, " + manifestORASArtifactContentType +

--- a/cmd/api/acrsdk.go
+++ b/cmd/api/acrsdk.go
@@ -21,10 +21,15 @@ import (
 
 // Constants that are used throughout this file.
 const (
-	prefixHTTPS           = "https://"
-	registryURL           = ".azurecr.io"
-	manifestTagFetchCount = 100
-	manifestV2ContentType = "application/vnd.docker.distribution.manifest.v2+json"
+	prefixHTTPS                      = "https://"
+	registryURL                      = ".azurecr.io"
+	manifestTagFetchCount            = 100
+	manifestOCIArtifactContentType   = "application/vnd.oci.artifact.manifest.v1+json"
+	manifestOCIImageContentType      = "application/vnd.oci.image.manifest.v1+json"
+	manifestOCIImageIndexContentType = "application/vnd.oci.image.index.v1+json"
+	manifestImageContentType         = "application/vnd.docker.distribution.manifest.v2+json"
+	manifestListContentType          = "application/vnd.docker.distribution.manifest.list.v2+json"
+	manifestAcceptHeader             = "*/*, " + manifestOCIArtifactContentType + ", " + manifestOCIImageContentType + ", " + manifestOCIImageIndexContentType + ", " + manifestImageContentType + ", " + manifestListContentType
 )
 
 // The AcrCLIClient is the struct that will be in charge of doing the http requests to the registry.
@@ -251,7 +256,7 @@ func (c *AcrCLIClient) GetManifest(ctx context.Context, repoName string, referen
 		}
 	}
 	var result acrapi.SetObject
-	req, err := c.AutorestClient.GetManifestPreparer(ctx, repoName, reference, manifestV2ContentType)
+	req, err := c.AutorestClient.GetManifestPreparer(ctx, repoName, reference, manifestAcceptHeader)
 	if err != nil {
 		err = autorest.NewErrorWithError(err, "acr.BaseClient", "GetManifest", nil, "Failure preparing request")
 		return nil, err

--- a/cmd/api/acrsdk.go
+++ b/cmd/api/acrsdk.go
@@ -24,12 +24,18 @@ const (
 	prefixHTTPS                      = "https://"
 	registryURL                      = ".azurecr.io"
 	manifestTagFetchCount            = 100
+	manifestORASArtifactContentType  = "application/vnd.cncf.oras.artifact.manifest.v1+json"
 	manifestOCIArtifactContentType   = "application/vnd.oci.artifact.manifest.v1+json"
 	manifestOCIImageContentType      = "application/vnd.oci.image.manifest.v1+json"
 	manifestOCIImageIndexContentType = "application/vnd.oci.image.index.v1+json"
 	manifestImageContentType         = "application/vnd.docker.distribution.manifest.v2+json"
 	manifestListContentType          = "application/vnd.docker.distribution.manifest.list.v2+json"
-	manifestAcceptHeader             = "*/*, " + manifestOCIArtifactContentType + ", " + manifestOCIImageContentType + ", " + manifestOCIImageIndexContentType + ", " + manifestImageContentType + ", " + manifestListContentType
+	manifestAcceptHeader             = "*/*, " + manifestORASArtifactContentType +
+		", " + manifestOCIArtifactContentType +
+		", " + manifestOCIImageContentType +
+		", " + manifestOCIImageIndexContentType +
+		", " + manifestImageContentType +
+		", " + manifestListContentType
 )
 
 // The AcrCLIClient is the struct that will be in charge of doing the http requests to the registry.

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.4.1
 	github.com/google/uuid v1.3.0
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6
+	github.com/opencontainers/image-spec v1.0.2
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.4.0
@@ -30,7 +31,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/kr/pretty v0.3.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/oras-project/artifacts-spec v1.0.0-rc.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect


### PR DESCRIPTION
**Purpose of the PR**

- add complete oci and docker image media-type to the accept header

Fixes #131

NOTE: #130 added the multi-arch support for oci image index but the command could still run into the error `[{"errors":[{"code":"MANIFEST_UNKNOWN","message":"OCI index found, but accept header does not support OCI indexes"}]}]`. The pr addresses the problem.