### PR TITLE
fix: update deprecated fields in goreleaser

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -31,6 +31,6 @@ jobs:
         uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,12 +19,13 @@ archives:
     files:
       - LICENSE
       - README.md
-    replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+    name_template: >-
+      {{- if eq .Arch "darwin" }}Darwin
+      {{- else if eq .Arch "linux" }}Linux
+      {{- else if eq .Arch "windows" }}Windows
+      {{- else if eq .Arch "386" }}i386
+      {{- else if eq .Arch "amd64" }}x86_64
+
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,16 +20,20 @@ archives:
       - LICENSE
       - README.md
     name_template: >-
+      {{- .ProjectName}}_
+      {{- .Version }}_
+      {{- title .Os }}_
       {{- if eq .Arch "darwin" }}Darwin
       {{- else if eq .Arch "linux" }}Linux
       {{- else if eq .Arch "windows" }}Windows
       {{- else if eq .Arch "386" }}i386
       {{- else if eq .Arch "amd64" }}x86_64
+      {{- else }}{{ .Arch }}{{ end }}
 
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  name_template: "{{ .Tag }}"
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
**Purpose of the PR**
the achrives.replacements field in goreleaser.yml is deprecated so our Action will throw error during release. 
- 

Fixes #