### PR TITLE
feat: cssc patch command to enable continuous patching

### DIFF
--- a/cmd/acr/cssc.go
+++ b/cmd/acr/cssc.go
@@ -1,0 +1,324 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	orasauth "github.com/Azure/acr-cli/auth/oras"
+	"github.com/Azure/acr-cli/cmd/api"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	oras "oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/content"
+	"oras.land/oras-go/v2/registry/remote"
+	"oras.land/oras-go/v2/registry/remote/auth"
+	"oras.land/oras-go/v2/registry/remote/retry"
+)
+
+const (
+	newCsscCmdLongMessage  = `acr cssc: CSSC (Container Secure Supply Chain) operations for a registry. Use subcommands for more specific operations.`
+	newPatchCmdLongMessage = `acr cssc patch: List all repositories and tags that match the filter.
+	Use the --filter-policy flag to specify the repository:tag where the filter file exists. If no filter policy is provided, the default filter policy is continuouspatchpolicy:latest
+	Example: acr cssc patch -r example --filter-policy continuouspatchpolicy:latest
+	Use the --show-patch-tags flag to also get patch image tag (if it exists) for repositories and tags that match the filter.
+	Example: acr cssc patch -r example --filter-policy continuouspatchpolicy:latest --show-patch-tags
+	Use the --dry-run flag in combination with --file-path flag to read filter from file path instead of filter policy.
+	Use this to validate the filter file without uploading it to the registry.
+	Example: acr cssc patch -r example --dry-run --file-path /path/to/filter.json
+	
+	Filter JSON file format:
+	{
+		"version": "v1",
+		"repositories": [
+			{
+				"repository": "example",
+				"tags": ["tag1", "tag2"],
+				"enabled": true
+			}
+		]
+	}
+`
+)
+
+type csscParameters struct {
+	*rootParameters
+	filterPolicy  string
+	showPatchTags bool
+	dryRun        bool
+	filePath      string
+}
+
+type Repository struct {
+	Repository string   `json:"repository"`
+	Tags       []string `json:"tags"`
+	Enabled    *bool    `json:"enabled"`
+}
+
+type Filter struct {
+	Version      string       `json:"version"`
+	Repositories []Repository `json:"repositories"`
+}
+
+type FilteredRepository struct {
+	Repository string
+	Tag        string
+	PatchTag   string
+}
+
+// The cssc command can be used to list cssc configurations for a registry.
+func newCsscCmd(rootParams *rootParameters) *cobra.Command {
+	csscParams := csscParameters{rootParameters: rootParams}
+	cmd := &cobra.Command{
+		Use:   "cssc",
+		Short: "cssc operations for a registry",
+		Long:  newCsscCmdLongMessage,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cmd.Help()
+			return nil
+		},
+	}
+
+	newCsscPatchFilterCmd := newPatchFilterCmd(&csscParams)
+
+	cmd.AddCommand(
+		newCsscPatchFilterCmd,
+	)
+
+	return cmd
+}
+
+// The patch subcommand can be used to list cssc continuous patch filters for a registry.
+func newPatchFilterCmd(csscParams *csscParameters) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "patch",
+		Short: "Manage cssc patch operations for a registry",
+		Long:  newPatchCmdLongMessage,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			ctx := context.Background()
+			registryName, err := csscParams.GetRegistryName()
+			if err != nil {
+				return err
+			}
+			loginURL := api.LoginURL(registryName)
+			acrClient, err := api.GetAcrCLIClientWithAuth(loginURL, csscParams.username, csscParams.password, csscParams.configs)
+			if err != nil {
+				return err
+			}
+
+			filter := Filter{}
+			if csscParams.dryRun == false && csscParams.filePath != "" {
+				return errors.New("flag --file-path can only be used in combination with --dry-run flag")
+			} else if csscParams.dryRun == true {
+				if csscParams.filePath == "" {
+					return errors.New("flag --file-path is required when using --dry-run flag")
+				}
+				fmt.Println("DRY RUN mode enabled. Reading filter from file path...")
+				filter, err = getFilterFromFilePath(csscParams.filePath)
+				if err != nil {
+					return err
+				}
+			} else if csscParams.filterPolicy != "" {
+				fmt.Println("Reading filter from filter policy...")
+				filter, err = getFilterFromFilterPolicy(ctx, csscParams, loginURL)
+				if err != nil {
+					return err
+				}
+			}
+
+			// Continue only if the filter is not empty
+			if len(filter.Repositories) == 0 {
+				fmt.Println("Filter is empty or invalid.")
+				return nil
+			}
+
+			filteredResult, err := applyFilterAndGetFilteredList(ctx, acrClient, filter)
+			if err != nil {
+				return err
+			}
+
+			printFilteredResult(filteredResult, csscParams, loginURL)
+			return nil
+		},
+	}
+
+	cmd.PersistentFlags().StringVar(&csscParams.filterPolicy, "filter-policy", "continuouspatchpolicy:latest", "The filter policy defined by the filter json file uploaded in a repo:tag. For v1, it will be continuouspatchpolicy:latest")
+	cmd.PersistentFlags().BoolVar(&csscParams.dryRun, "dry-run", false, "Use this in combination with --file-path to read filter from file path instead of filter policy. This allows to validate the filter file without uploading it to the registry.")
+	cmd.PersistentFlags().StringVar(&csscParams.filePath, "file-path", "", "The file path of the JSON filter file. Use this in combination with --dry-run to simulate the operation without making any changes on the registry.")
+	cmd.Flags().BoolVar(&csscParams.showPatchTags, "show-patch-tags", false, "Use this flag to get patch tag (if it exists) for repositories and tags that match the filter. Example: acr cssc patch --filter-policy continuouspatchpolicy:latest --show-patch-tags")
+	return cmd
+}
+
+func getFilterFromFilterPolicy(ctx context.Context, csscParams *csscParameters, loginURL string) (Filter, error) {
+	// Validate the filter policy format
+	if !strings.Contains(csscParams.filterPolicy, ":") {
+		return Filter{}, errors.New("filter-policy should be in the format repo:tag")
+	}
+	repoTag := strings.Split(csscParams.filterPolicy, ":")
+	filterRepoName := repoTag[0]
+	filterRepoTagName := repoTag[1]
+
+	// Connect to the remote repository
+	repo, err := remote.NewRepository(fmt.Sprintf("%s/%s", loginURL, filterRepoName))
+	if err != nil {
+		panic(err)
+	}
+	getRegistryCredsFromStore(csscParams, loginURL)
+	repo.Client = &auth.Client{
+		Client: retry.DefaultClient,
+		Cache:  auth.NewCache(),
+		Credential: auth.StaticCredential(loginURL, auth.Credential{
+			Username: csscParams.username,
+			Password: csscParams.password,
+		}),
+	}
+
+	// Get manifest and read content
+	_, pulledManifestContent, err := oras.FetchBytes(ctx, repo, filterRepoTagName, oras.DefaultFetchBytesOptions)
+	if err != nil {
+		return Filter{}, errors.Wrap(err, "error fetching manifest content when reading the filter policy")
+	}
+	var pulledManifest v1.Manifest
+	if err := json.Unmarshal(pulledManifestContent, &pulledManifest); err != nil {
+		panic(err)
+	}
+	var fileContent []byte
+	for _, layer := range pulledManifest.Layers {
+		fileContent, err = content.FetchAll(ctx, repo, layer)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	// Unmarshal the JSON file data to Filter struct
+	var filter = Filter{}
+	if err := json.Unmarshal(fileContent, &filter); err != nil {
+		return Filter{}, errors.Wrap(err, "error unmarshalling json content when reading the filter policy")
+	}
+
+	return filter, nil
+}
+
+func getFilterFromFilePath(filePath string) (Filter, error) {
+	file, err := os.ReadFile(filePath)
+	if err != nil {
+		return Filter{}, errors.Wrap(err, "error reading the filter json file from file path")
+	}
+
+	var filter = Filter{}
+	if err := json.Unmarshal(file, &filter); err != nil {
+		return Filter{}, errors.Wrap(err, "error unmarshalling json content when reading the filter file from file path")
+	}
+
+	return filter, nil
+}
+
+func applyFilterAndGetFilteredList(ctx context.Context, acrClient api.AcrCLIClientInterface, filter Filter) ([]FilteredRepository, error) {
+	var filteredRepos []FilteredRepository
+
+	for _, filterRepo := range filter.Repositories {
+		if filterRepo.Enabled != nil && *filterRepo.Enabled == false {
+			continue
+		}
+		if filterRepo.Repository == "" || filterRepo.Tags == nil || len(filterRepo.Tags) == 0 || filterRepo.Tags[0] == "" {
+			continue
+		}
+
+		tagList, err := listTags(ctx, acrClient, filterRepo.Repository)
+		if err != nil {
+			if strings.Contains(err.Error(), "404") {
+				continue
+			}
+			return nil, err
+		}
+
+		if len(filterRepo.Tags) == 1 && filterRepo.Tags[0] == "*" {
+			for _, tag := range tagList {
+				if strings.Contains(*tag.Name, "-patched") {
+					originalTag := strings.Split(*tag.Name, "-patched")[0]
+					matchingRepo := FilteredRepository{Repository: filterRepo.Repository, Tag: originalTag, PatchTag: *tag.Name}
+					filteredRepos = appendElement(filteredRepos, matchingRepo)
+				} else {
+					matchingRepo := FilteredRepository{Repository: filterRepo.Repository, Tag: *tag.Name, PatchTag: *tag.Name}
+					filteredRepos = appendElement(filteredRepos, matchingRepo)
+				}
+			}
+		} else {
+			for _, ftag := range filterRepo.Tags {
+				for _, tag := range tagList {
+					if *tag.Name == ftag {
+						matchingRepo := FilteredRepository{Repository: filterRepo.Repository, Tag: *tag.Name, PatchTag: *tag.Name}
+						filteredRepos = appendElement(filteredRepos, matchingRepo)
+					} else if *tag.Name == ftag+"-patched" {
+						matchingRepo := FilteredRepository{Repository: filterRepo.Repository, Tag: ftag, PatchTag: ftag + "-patched"}
+						filteredRepos = appendElement(filteredRepos, matchingRepo)
+					}
+				}
+			}
+		}
+	}
+	return filteredRepos, nil
+}
+
+func getRegistryCredsFromStore(csscParams *csscParameters, loginURL string) {
+	// If both username and password are empty then the docker config file will be used, it can be found in the default
+	// location or in a location specified by the configs string array
+	if csscParams.username == "" || csscParams.password == "" {
+		store, err := orasauth.NewStore(csscParams.configs...)
+		if err != nil {
+			errors.Wrap(err, "error resolving authentication")
+		}
+		cred, err := store.Credential(context.Background(), loginURL)
+		if err != nil {
+			errors.Wrap(err, "error resolving authentication")
+		}
+		csscParams.username = cred.Username
+		csscParams.password = cred.Password
+
+		// fallback to refresh token if it is available
+		if csscParams.password == "" && cred.RefreshToken != "" {
+			csscParams.password = cred.RefreshToken
+		}
+	}
+}
+
+func appendElement(slice []FilteredRepository, element FilteredRepository) []FilteredRepository {
+	for _, existing := range slice {
+		if existing.Repository == element.Repository && existing.Tag == element.Tag {
+			// Remove the existing element from the slice
+			for i, v := range slice {
+				if v.Repository == element.Repository && v.Tag == element.Tag {
+					slice = append(slice[:i], slice[i+1:]...)
+					break
+				}
+			}
+		}
+	}
+	// Append the new element to the slice
+	return append(slice, element)
+}
+
+func printFilteredResult(filteredResult []FilteredRepository, csscParams *csscParameters, loginURL string) {
+	if len(filteredResult) == 0 {
+		fmt.Println("No matching repository and tag found!")
+	}
+	if csscParams.showPatchTags {
+		fmt.Println("Listing repositories and tags matching the filter with corrosponding patch tag (if present):")
+		for _, result := range filteredResult {
+			fmt.Printf("%s/%s:%s,%s\n", loginURL, result.Repository, result.Tag, result.PatchTag)
+		}
+	} else {
+		fmt.Println("Listing repositories and tags matching the filter:")
+		for _, result := range filteredResult {
+			fmt.Printf("%s/%s:%s\n", loginURL, result.Repository, result.Tag)
+		}
+	}
+	fmt.Println("Total matches found:", len(filteredResult))
+}

--- a/cmd/acr/cssc.go
+++ b/cmd/acr/cssc.go
@@ -5,33 +5,24 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"os"
-	"strings"
 
 	orasauth "github.com/Azure/acr-cli/auth/oras"
+	"github.com/Azure/acr-cli/internal/cssc"
+
 	"github.com/Azure/acr-cli/cmd/api"
-	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-
-	oras "oras.land/oras-go/v2"
-	"oras.land/oras-go/v2/content"
-	"oras.land/oras-go/v2/registry/remote"
-	"oras.land/oras-go/v2/registry/remote/auth"
-	"oras.land/oras-go/v2/registry/remote/retry"
 )
 
 const (
 	newCsscCmdLongMessage  = `acr cssc: CSSC (Container Secure Supply Chain) operations for a registry. Use subcommands for more specific operations.`
 	newPatchCmdLongMessage = `acr cssc patch: List all repositories and tags that match the filter.
-	Use the --filter-policy flag to specify the repository:tag where the filter file exists. If no filter policy is provided, the default filter policy is continuouspatchpolicy:latest
+	Use the --filter-policy flag to specify the repository:tag where the filter exists. For v1, it should be continuouspatchpolicy:latest
 	Example: acr cssc patch -r example --filter-policy continuouspatchpolicy:latest
-	Use the --show-patch-tags flag to also get patch image tag (if it exists) for repositories and tags that match the filter.
+	Use the --show-patch-tags flag to get patch tag (if it exists) for repositories and tags that match the filter.
 	Example: acr cssc patch -r example --filter-policy continuouspatchpolicy:latest --show-patch-tags
-	Use the --dry-run flag in combination with --file-path flag to read filter from file path instead of filter policy.
-	Use this to validate the filter file without uploading it to the registry.
+	Use the --dry-run flag in combination with --file-path flag to read filter from a local file path instead of filter policy.	Use this to validate the filter file before using it as filter policy.
 	Example: acr cssc patch -r example --dry-run --file-path /path/to/filter.json
 	
 	Filter JSON file format:
@@ -54,23 +45,6 @@ type csscParameters struct {
 	showPatchTags bool
 	dryRun        bool
 	filePath      string
-}
-
-type Repository struct {
-	Repository string   `json:"repository"`
-	Tags       []string `json:"tags"`
-	Enabled    *bool    `json:"enabled"`
-}
-
-type Filter struct {
-	Version      string       `json:"version"`
-	Repositories []Repository `json:"repositories"`
-}
-
-type FilteredRepository struct {
-	Repository string
-	Tag        string
-	PatchTag   string
 }
 
 // The cssc command can be used to list cssc configurations for a registry.
@@ -108,163 +82,50 @@ func newPatchFilterCmd(csscParams *csscParameters) *cobra.Command {
 				return err
 			}
 			loginURL := api.LoginURL(registryName)
+			getRegistryCredsFromStore(csscParams, loginURL)
 			acrClient, err := api.GetAcrCLIClientWithAuth(loginURL, csscParams.username, csscParams.password, csscParams.configs)
 			if err != nil {
 				return err
 			}
 
-			filter := Filter{}
-			if csscParams.dryRun == false && csscParams.filePath != "" {
-				return errors.New("flag --file-path can only be used in combination with --dry-run flag")
-			} else if csscParams.dryRun == true {
+			filter := cssc.Filter{}
+			if !csscParams.dryRun && csscParams.filePath != "" {
+				return errors.New("flag --file-path can only be used in combination with --dry-run")
+			} else if csscParams.dryRun {
 				if csscParams.filePath == "" {
-					return errors.New("flag --file-path is required when using --dry-run flag")
+					return errors.New("flag --file-path is required when using --dry-run")
 				}
 				fmt.Println("DRY RUN mode enabled. Reading filter from file path...")
-				filter, err = getFilterFromFilePath(csscParams.filePath)
+				filter, err = cssc.GetFilterFromFilePath(csscParams.filePath)
 				if err != nil {
 					return err
 				}
 			} else if csscParams.filterPolicy != "" {
 				fmt.Println("Reading filter from filter policy...")
-				filter, err = getFilterFromFilterPolicy(ctx, csscParams, loginURL)
+				filter, err = cssc.GetFilterFromFilterPolicy(ctx, csscParams.filterPolicy, loginURL, csscParams.username, csscParams.password)
 				if err != nil {
 					return err
 				}
 			}
 
-			// Continue only if the filter is not empty
 			if len(filter.Repositories) == 0 {
 				fmt.Println("Filter is empty or invalid.")
 				return nil
 			}
-
-			filteredResult, err := applyFilterAndGetFilteredList(ctx, acrClient, filter)
+			filteredResult, err := cssc.ApplyFilterAndGetFilteredList(ctx, acrClient, filter)
 			if err != nil {
 				return err
 			}
-
-			printFilteredResult(filteredResult, csscParams, loginURL)
+			cssc.PrintFilteredResult(filteredResult, csscParams.showPatchTags, loginURL)
 			return nil
 		},
 	}
 
-	cmd.PersistentFlags().StringVar(&csscParams.filterPolicy, "filter-policy", "continuouspatchpolicy:latest", "The filter policy defined by the filter json file uploaded in a repo:tag. For v1, it will be continuouspatchpolicy:latest")
+	cmd.PersistentFlags().StringVar(&csscParams.filterPolicy, "filter-policy", "", "The filter policy defined by the filter json file uploaded in a repo:tag. For v1, it should be continuouspatchpolicy:latest")
 	cmd.PersistentFlags().BoolVar(&csscParams.dryRun, "dry-run", false, "Use this in combination with --file-path to read filter from file path instead of filter policy. This allows to validate the filter file without uploading it to the registry.")
 	cmd.PersistentFlags().StringVar(&csscParams.filePath, "file-path", "", "The file path of the JSON filter file. Use this in combination with --dry-run to simulate the operation without making any changes on the registry.")
 	cmd.Flags().BoolVar(&csscParams.showPatchTags, "show-patch-tags", false, "Use this flag to get patch tag (if it exists) for repositories and tags that match the filter. Example: acr cssc patch --filter-policy continuouspatchpolicy:latest --show-patch-tags")
 	return cmd
-}
-
-func getFilterFromFilterPolicy(ctx context.Context, csscParams *csscParameters, loginURL string) (Filter, error) {
-	// Validate the filter policy format
-	if !strings.Contains(csscParams.filterPolicy, ":") {
-		return Filter{}, errors.New("filter-policy should be in the format repo:tag")
-	}
-	repoTag := strings.Split(csscParams.filterPolicy, ":")
-	filterRepoName := repoTag[0]
-	filterRepoTagName := repoTag[1]
-
-	// Connect to the remote repository
-	repo, err := remote.NewRepository(fmt.Sprintf("%s/%s", loginURL, filterRepoName))
-	if err != nil {
-		panic(err)
-	}
-	getRegistryCredsFromStore(csscParams, loginURL)
-	repo.Client = &auth.Client{
-		Client: retry.DefaultClient,
-		Cache:  auth.NewCache(),
-		Credential: auth.StaticCredential(loginURL, auth.Credential{
-			Username: csscParams.username,
-			Password: csscParams.password,
-		}),
-	}
-
-	// Get manifest and read content
-	_, pulledManifestContent, err := oras.FetchBytes(ctx, repo, filterRepoTagName, oras.DefaultFetchBytesOptions)
-	if err != nil {
-		return Filter{}, errors.Wrap(err, "error fetching manifest content when reading the filter policy")
-	}
-	var pulledManifest v1.Manifest
-	if err := json.Unmarshal(pulledManifestContent, &pulledManifest); err != nil {
-		panic(err)
-	}
-	var fileContent []byte
-	for _, layer := range pulledManifest.Layers {
-		fileContent, err = content.FetchAll(ctx, repo, layer)
-		if err != nil {
-			panic(err)
-		}
-	}
-
-	// Unmarshal the JSON file data to Filter struct
-	var filter = Filter{}
-	if err := json.Unmarshal(fileContent, &filter); err != nil {
-		return Filter{}, errors.Wrap(err, "error unmarshalling json content when reading the filter policy")
-	}
-
-	return filter, nil
-}
-
-func getFilterFromFilePath(filePath string) (Filter, error) {
-	file, err := os.ReadFile(filePath)
-	if err != nil {
-		return Filter{}, errors.Wrap(err, "error reading the filter json file from file path")
-	}
-
-	var filter = Filter{}
-	if err := json.Unmarshal(file, &filter); err != nil {
-		return Filter{}, errors.Wrap(err, "error unmarshalling json content when reading the filter file from file path")
-	}
-
-	return filter, nil
-}
-
-func applyFilterAndGetFilteredList(ctx context.Context, acrClient api.AcrCLIClientInterface, filter Filter) ([]FilteredRepository, error) {
-	var filteredRepos []FilteredRepository
-
-	for _, filterRepo := range filter.Repositories {
-		if filterRepo.Enabled != nil && *filterRepo.Enabled == false {
-			continue
-		}
-		if filterRepo.Repository == "" || filterRepo.Tags == nil || len(filterRepo.Tags) == 0 || filterRepo.Tags[0] == "" {
-			continue
-		}
-
-		tagList, err := listTags(ctx, acrClient, filterRepo.Repository)
-		if err != nil {
-			if strings.Contains(err.Error(), "404") {
-				continue
-			}
-			return nil, err
-		}
-
-		if len(filterRepo.Tags) == 1 && filterRepo.Tags[0] == "*" {
-			for _, tag := range tagList {
-				if strings.Contains(*tag.Name, "-patched") {
-					originalTag := strings.Split(*tag.Name, "-patched")[0]
-					matchingRepo := FilteredRepository{Repository: filterRepo.Repository, Tag: originalTag, PatchTag: *tag.Name}
-					filteredRepos = appendElement(filteredRepos, matchingRepo)
-				} else {
-					matchingRepo := FilteredRepository{Repository: filterRepo.Repository, Tag: *tag.Name, PatchTag: *tag.Name}
-					filteredRepos = appendElement(filteredRepos, matchingRepo)
-				}
-			}
-		} else {
-			for _, ftag := range filterRepo.Tags {
-				for _, tag := range tagList {
-					if *tag.Name == ftag {
-						matchingRepo := FilteredRepository{Repository: filterRepo.Repository, Tag: *tag.Name, PatchTag: *tag.Name}
-						filteredRepos = appendElement(filteredRepos, matchingRepo)
-					} else if *tag.Name == ftag+"-patched" {
-						matchingRepo := FilteredRepository{Repository: filterRepo.Repository, Tag: ftag, PatchTag: ftag + "-patched"}
-						filteredRepos = appendElement(filteredRepos, matchingRepo)
-					}
-				}
-			}
-		}
-	}
-	return filteredRepos, nil
 }
 
 func getRegistryCredsFromStore(csscParams *csscParameters, loginURL string) {
@@ -287,38 +148,4 @@ func getRegistryCredsFromStore(csscParams *csscParameters, loginURL string) {
 			csscParams.password = cred.RefreshToken
 		}
 	}
-}
-
-func appendElement(slice []FilteredRepository, element FilteredRepository) []FilteredRepository {
-	for _, existing := range slice {
-		if existing.Repository == element.Repository && existing.Tag == element.Tag {
-			// Remove the existing element from the slice
-			for i, v := range slice {
-				if v.Repository == element.Repository && v.Tag == element.Tag {
-					slice = append(slice[:i], slice[i+1:]...)
-					break
-				}
-			}
-		}
-	}
-	// Append the new element to the slice
-	return append(slice, element)
-}
-
-func printFilteredResult(filteredResult []FilteredRepository, csscParams *csscParameters, loginURL string) {
-	if len(filteredResult) == 0 {
-		fmt.Println("No matching repository and tag found!")
-	}
-	if csscParams.showPatchTags {
-		fmt.Println("Listing repositories and tags matching the filter with corrosponding patch tag (if present):")
-		for _, result := range filteredResult {
-			fmt.Printf("%s/%s:%s,%s\n", loginURL, result.Repository, result.Tag, result.PatchTag)
-		}
-	} else {
-		fmt.Println("Listing repositories and tags matching the filter:")
-		for _, result := range filteredResult {
-			fmt.Printf("%s/%s:%s\n", loginURL, result.Repository, result.Tag)
-		}
-	}
-	fmt.Println("Total matches found:", len(filteredResult))
 }

--- a/cmd/acr/cssc.go
+++ b/cmd/acr/cssc.go
@@ -94,7 +94,7 @@ func newPatchFilterCmd(csscParams *csscParameters) *cobra.Command {
 			} else if !csscParams.dryRun && csscParams.filterfilePath != "" {
 				return errors.New("flag --filter-file-path can only be used in combination with --dry-run")
 			} else if !csscParams.dryRun && csscParams.filterPolicy != "" {
-				return errors.New("patch command without --dry-run is not fully operational and will be enabled in future releases")
+				return errors.New("patch command without --dry-run is not operational at the moment and will be enabled in future releases")
 			} else if csscParams.dryRun {
 				fmt.Println("DRY RUN mode enabled...")
 				if csscParams.filterPolicy == "" && csscParams.filterfilePath == "" {

--- a/cmd/acr/cssc.go
+++ b/cmd/acr/cssc.go
@@ -20,7 +20,7 @@ const (
 	newPatchCmdLongMessage = `[Preview] acr cssc patch: Run cssc patch operation for a registry. Use flags for more specific operations.
 	
 	Use the --filter-policy flag to specify the repository:tag where the filter json exists as an OCI artifact and --dry-run flag to list the filtered repositories and tags that match the filter.
-	Example: acr cssc patch -r example --filter-policy continuouspatchpolicy:latest --dry-run
+	Example: acr cssc patch -r example --filter-policy csscpolicies/patchpolicy:v1 --dry-run
 	
 	Use the --filter-file-path flag to specify the local file path where the filter json exists and --dry-run flag to list the filtered repositories and tags that match the filter.
 	Example: acr cssc patch -r example --filter-file-path /path/to/filter.json --dry-run
@@ -128,10 +128,10 @@ func newPatchFilterCmd(csscParams *csscParameters) *cobra.Command {
 		},
 	}
 
-	cmd.PersistentFlags().StringVar(&csscParams.filterPolicy, "filter-policy", "", "The filter policy defined by the filter json file uploaded in a repo:tag. For v1, it should be continuouspatchpolicy:latest")
+	cmd.PersistentFlags().StringVar(&csscParams.filterPolicy, "filter-policy", "", "The filter policy defined by the filter json file uploaded in a repo:tag. For v1, it should be csscpolicies/patchpolicy:v1")
 	cmd.PersistentFlags().BoolVar(&csscParams.dryRun, "dry-run", false, "Use this to list the filtered repositories and tags that match the filter either from a filter policy or a filter file path. ")
 	cmd.PersistentFlags().StringVar(&csscParams.filterfilePath, "filter-file-path", "", "The filter file path of the JSON filter file.")
-	cmd.Flags().BoolVar(&csscParams.showPatchTags, "show-patch-tags", false, "Use this flag to get patch tag (if it exists) for repositories and tags that match the filter. Example: acr cssc patch --filter-policy continuouspatchpolicy:latest --show-patch-tags")
+	cmd.Flags().BoolVar(&csscParams.showPatchTags, "show-patch-tags", false, "Use this flag to get patch tag (if it exists) for repositories and tags that match the filter. Example: acr cssc patch --filter-policy csscpolicies/patchpolicy:v1 --show-patch-tags")
 	return cmd
 }
 

--- a/cmd/acr/cssc.go
+++ b/cmd/acr/cssc.go
@@ -8,9 +8,8 @@ import (
 	"fmt"
 
 	orasauth "github.com/Azure/acr-cli/auth/oras"
+	"github.com/Azure/acr-cli/internal/api"
 	"github.com/Azure/acr-cli/internal/cssc"
-
-	"github.com/Azure/acr-cli/cmd/api"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )

--- a/cmd/acr/cssc.go
+++ b/cmd/acr/cssc.go
@@ -97,6 +97,7 @@ func newPatchFilterCmd(csscParams *csscParameters) *cobra.Command {
 				return errors.New("patch command without --dry-run is not operational at the moment and will be enabled in future releases")
 			} else if csscParams.dryRun {
 				fmt.Println("DRY RUN mode enabled...")
+				fmt.Println("DRY RUN mode will only list all the repositories and tags that match the filter and are eligible for continuous scan and patch. During the actual patch operation, each of the eligible images will first be scanned using trivy and if there are any vulnerabilities found, a new patched image will be generated with tag <originaltag>-patched.")
 				if csscParams.filterPolicy == "" && csscParams.filterfilePath == "" {
 					return errors.New("flag --filter-policy or --filter-file-path is required when using --dry-run")
 				} else if csscParams.filterfilePath != "" {

--- a/cmd/acr/cssc_test.go
+++ b/cmd/acr/cssc_test.go
@@ -1,382 +1,50 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package main
 
 import (
-	"context"
-	"net/http"
-	"os"
 	"testing"
 
-	"github.com/Azure/acr-cli/acr"
-	"github.com/Azure/acr-cli/cmd/mocks"
-	"github.com/Azure/go-autorest/autorest"
-	"github.com/pkg/errors"
+	"github.com/Azure/acr-cli/internal/common"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestApplyFilterAndGetFilteredList(t *testing.T) {
-	mockAcrClient := &mocks.AcrCLIClientInterface{}
-
-	// 1. If filter contains only one repository and it is not specified, nothing will match the filter and an empty list should be returned
-	t.Run("RepositoryNotSpecifiedTest", func(t *testing.T) {
-		filter := Filter{
-			Version: "v1",
-			Repositories: []Repository{
-				{
-					Repository: "",
-					Tags:       []string{csscTestTag1, csscTestTag2},
-					Enabled:    boolPtr(true),
-				},
-			},
-		}
-
-		filteredRepositories, err := applyFilterAndGetFilteredList(context.Background(), mockAcrClient, filter)
-		assert.NoError(t, err)
-		assert.Nil(t, filteredRepositories)
-		assert.Len(t, filteredRepositories, 0)
-	})
-
-	//2.  If Tags are not specified for any repository in the filter, nothing will match the filter and an empty list should be returned
-	t.Run("TagsNotSpecifiedTest", func(t *testing.T) {
-		filter := Filter{
-			Version: "v1",
-			Repositories: []Repository{
-				{
-					Repository: csscTestRepo1,
-					Tags:       nil,
-					Enabled:    boolPtr(true),
-				},
-				{
-					Repository: csscTestRepo2,
-					Tags:       []string{""},
-					Enabled:    boolPtr(true),
-				},
-			},
-		}
-		filteredRepositories, err := applyFilterAndGetFilteredList(context.Background(), mockAcrClient, filter)
-		assert.NoError(t, err)
-		assert.Nil(t, filteredRepositories)
-		assert.Len(t, filteredRepositories, 0)
-	})
-
-	//3. Error should be returned when GetAcrTags fails for a repository
-	t.Run("GetAcrTagsFailsTest", func(t *testing.T) {
-		filter := Filter{
-			Version: "v1",
-			Repositories: []Repository{
-				{
-					Repository: csscTestRepo1,
-					Tags:       []string{csscTestTag1, csscTestTag2},
-					Enabled:    boolPtr(true),
-				},
-			},
-		}
-		mockAcrClient.On("GetAcrTags", csscTestCtx, csscTestRepo1, "", "").Return(nil, errors.New("failed getting the tags")).Once()
-		filteredRepositories, err := applyFilterAndGetFilteredList(context.Background(), mockAcrClient, filter)
-		assert.Error(t, err)
-		assert.ErrorContains(t, err, "failed getting the tags")
-		assert.Nil(t, filteredRepositories)
-	})
-
-	//4. If filter has a tag that doesn't exist in the repository, ignore it and return whatever exists that matches the filter
-	t.Run("TagSpecifiedInFilterDoesNotExistTest", func(t *testing.T) {
-		filter := Filter{
-			Version: "v1",
-			Repositories: []Repository{
-				{
-					Repository: csscTestRepo1,
-					Tags:       []string{csscTestTag1, csscTestTag2},
-					Enabled:    boolPtr(true),
-				},
-			},
-		}
-		mockAcrClient.On("GetAcrTags", csscTestCtx, csscTestRepo1, "", "").Return(CsscTestOneTagResult, nil).Once()
-		mockAcrClient.On("GetAcrTags", csscTestCtx, csscTestRepo1, "", csscTestTag1).Return(EmptyListTagsResult, nil).Once()
-
-		filteredRepositories, err := applyFilterAndGetFilteredList(context.Background(), mockAcrClient, filter)
-		assert.NoError(t, err)
-		assert.Len(t, filteredRepositories, 1) //
-		assert.Equal(t, csscTestRepo1, filteredRepositories[0].Repository)
-		assert.Equal(t, csscTestTag1, filteredRepositories[0].Tag)
-	})
-
-	// 5. Success scenario with all the combination of filters
-	t.Run("AllFilterCombinationTest", func(t *testing.T) {
-		filter := Filter{
-			Version: "v1",
-			Repositories: []Repository{
-				{
-					Repository: csscTestRepo1,
-					Tags:       []string{csscTestTag1, csscTestTag2}, // tags specified
-					Enabled:    boolPtr(true),
-				},
-				{
-					Repository: csscTestRepo2,
-					Tags:       []string{"*"}, // * all tags
-					Enabled:    boolPtr(true),
-				},
-				{
-					Repository: csscTestRepo3,
-					Tags:       []string{csscTestTag1, csscTestTag2},
-					Enabled:    nil, // nil means enabled
-				},
-				{
-					Repository: csscTestRepo4,
-					Tags:       []string{csscTestTag1, csscTestTag2},
-					Enabled:    boolPtr(false), // disabled repository for all tags
-				},
-			},
-		}
-		mockAcrClient.On("GetAcrTags", csscTestCtx, csscTestRepo1, "", "").Return(CsscTestTagResult, nil).Once()
-		mockAcrClient.On("GetAcrTags", csscTestCtx, csscTestRepo1, "", csscTestPatch2).Return(EmptyListTagsResult, nil).Once()
-		mockAcrClient.On("GetAcrTags", csscTestCtx, csscTestRepo2, "", "").Return(CsscTestTagResult, nil).Once()
-		mockAcrClient.On("GetAcrTags", csscTestCtx, csscTestRepo2, "", csscTestPatch2).Return(EmptyListTagsResult, nil).Once()
-		mockAcrClient.On("GetAcrTags", csscTestCtx, csscTestRepo3, "", "").Return(CsscTestTagResult, nil).Once()
-		mockAcrClient.On("GetAcrTags", csscTestCtx, csscTestRepo3, "", csscTestPatch2).Return(EmptyListTagsResult, nil).Once()
-		mockAcrClient.On("GetAcrTags", csscTestCtx, csscTestRepo4, "", "").Return(CsscTestTagResult, nil).Once()
-		mockAcrClient.On("GetAcrTags", csscTestCtx, csscTestRepo4, "", csscTestPatch2).Return(EmptyListTagsResult, nil).Once()
-
-		filteredRepositories, err := applyFilterAndGetFilteredList(context.Background(), mockAcrClient, filter)
-		assert.NoError(t, err)
-		assert.Len(t, filteredRepositories, 6)
-		assert.Equal(t, csscTestRepo1, filteredRepositories[0].Repository)
-		assert.Equal(t, csscTestTag1, filteredRepositories[0].Tag)
-		assert.Equal(t, csscTestPatch1, filteredRepositories[0].PatchTag)
-		assert.Equal(t, csscTestRepo1, filteredRepositories[1].Repository)
-		assert.Equal(t, csscTestTag2, filteredRepositories[1].Tag)
-		assert.Equal(t, csscTestPatch2, filteredRepositories[1].PatchTag)
-
-		assert.Equal(t, csscTestRepo2, filteredRepositories[2].Repository)
-		assert.Equal(t, csscTestTag1, filteredRepositories[2].Tag)
-		assert.Equal(t, csscTestPatch1, filteredRepositories[2].PatchTag)
-		assert.Equal(t, csscTestRepo2, filteredRepositories[3].Repository)
-		assert.Equal(t, csscTestTag2, filteredRepositories[3].Tag)
-		assert.Equal(t, csscTestPatch2, filteredRepositories[3].PatchTag)
-
-		assert.Equal(t, csscTestRepo3, filteredRepositories[4].Repository)
-		assert.Equal(t, csscTestTag1, filteredRepositories[4].Tag)
-		assert.Equal(t, csscTestPatch1, filteredRepositories[4].PatchTag)
-		assert.Equal(t, csscTestRepo3, filteredRepositories[5].Repository)
-		assert.Equal(t, csscTestTag2, filteredRepositories[5].Tag)
-		assert.Equal(t, csscTestPatch2, filteredRepositories[5].PatchTag)
-	})
-}
-
-func TestGetFilterFromFilterPolicy(t *testing.T) {
+func TestNewCsscCmd(t *testing.T) {
 	rootParams := &rootParameters{}
-	rootParams.username = "username"
-	rootParams.password = "password"
-	csscParams := csscParameters{rootParameters: rootParams}
-	loginURL := testLoginURL
-
-	//1. Error should be returned when filter policy is not in the correct format
-	t.Run("FilterPolicyNotCorrectFormatTest", func(t *testing.T) {
-		csscParams.filterPolicy = "notcorrectformat"
-		filter, err := getFilterFromFilterPolicy(context.Background(), &csscParams, loginURL)
-		assert.NotEqual(nil, err, "Error should not be nil")
-		assert.Equal(t, "filter-policy should be in the format repo:tag", err.Error())
-		assert.Equal(t, Filter{}, filter)
-	})
-
-	//2. Error should be returned when fetching repository manifest fails
-	t.Run("FetchBytesFailsTest", func(t *testing.T) {
-		csscParams.filterPolicy = "repo1:tag1"
-		filter, err := getFilterFromFilterPolicy(context.Background(), &csscParams, loginURL)
-		assert.NotEqual(nil, err, "Error should not be nil")
-		assert.ErrorContains(t, err, "error fetching manifest content when reading the filter policy")
-		assert.Equal(t, Filter{}, filter)
-	})
+	cmd := newCsscCmd(rootParams)
+	assert.NotNil(t, cmd)
+	assert.Equal(t, "cssc", cmd.Use)
+	assert.Equal(t, newCsscCmdLongMessage, cmd.Long)
 }
 
-func TestGetFilterFromFilePath(t *testing.T) {
-
-	//1. Error should be returned when filter file does not exist
-	t.Run("FileDoesNotExistTest", func(t *testing.T) {
-		filter, err := getFilterFromFilePath("idontexist")
-		assert.NotEqual(nil, err, "Error should not be nil")
-		assert.ErrorContains(t, err, "error reading the filter json file from file path")
-		assert.Equal(t, Filter{}, filter)
-	})
-
-	//2. Error should be returned when filter file is not in the correct format
-	t.Run("FileNotCorrectFormatTest", func(t *testing.T) {
-		var filterFile = []byte(`i am not a json file`)
-		err := os.WriteFile("filter-wrongformat.json", filterFile, 0600)
-
-		assert.Nil(t, err, "Error should be nil")
-		filter, err := getFilterFromFilePath("filter-wrongformat.json")
-		assert.NotEqual(nil, err, "Error should not be nil")
-		assert.ErrorContains(t, err, "error unmarshalling json content when reading the filter file from file path")
-		assert.Equal(t, Filter{}, filter)
-
-		err = os.Remove("filter-wrongformat.json")
-		assert.Nil(t, err, "Error should be nil")
-	})
-
-	//3. Success scenario with correct filter file
-	t.Run("SuccessTest", func(t *testing.T) {
-		var filterFile = []byte(`{
-			"version": "v1",
-			"repositories": [
-				{
-					"repository": "repo1",
-					"tags": ["tag1", "tag2"],
-					"enabled": true
-				},
-				{
-					"repository": "repo2",
-					"tags": ["tag1"],
-					"enabled": true
-				}
-			]
-		}`)
-		err := os.WriteFile("filter.json", filterFile, 0600)
-		assert.Nil(t, err, "Error should be nil")
-
-		filter, err := getFilterFromFilePath("filter.json")
-		assert.Nil(t, err, "Error should be nil")
-		assert.Equal(t, "v1", filter.Version)
-		assert.Len(t, filter.Repositories, 2)
-		assert.Equal(t, csscTestRepo1, filter.Repositories[0].Repository)
-		assert.Equal(t, csscTestTag1, filter.Repositories[0].Tags[0])
-		assert.Equal(t, csscTestTag2, filter.Repositories[0].Tags[1])
-		assert.Equal(t, true, *filter.Repositories[0].Enabled)
-		assert.Equal(t, csscTestRepo2, filter.Repositories[1].Repository)
-		assert.Equal(t, csscTestTag1, filter.Repositories[1].Tags[0])
-		assert.Equal(t, true, *filter.Repositories[1].Enabled)
-
-		err = os.Remove("filter.json")
-		assert.Nil(t, err, "Error should be nil")
-	})
+func TestNewPatchFilterCmd(t *testing.T) {
+	rootParams := &rootParameters{}
+	csscParams := csscParameters{rootParameters: rootParams}
+	cmd := newPatchFilterCmd(&csscParams)
+	assert.NotNil(t, cmd)
+	assert.Equal(t, "patch", cmd.Use)
+	assert.Equal(t, newPatchCmdLongMessage, cmd.Long)
 }
 
 func TestGetRegistryCredsFromStore(t *testing.T) {
 	rootParams := &rootParameters{}
 	rootParams.configs = []string{"config1", "config2"}
 	csscParams := csscParameters{rootParameters: rootParams}
-	loginURL := testLoginURL
-
 	// 1. Should not get the creds from the store when creds are provided
 	t.Run("CredsProvidedTest", func(t *testing.T) {
 		rootParams.username = "username"
 		rootParams.password = "password"
-		getRegistryCredsFromStore(&csscParams, loginURL)
+		getRegistryCredsFromStore(&csscParams, common.TestLoginURL)
 		assert.Equal(t, "username", csscParams.username)
 		assert.Equal(t, "password", csscParams.password)
 	})
-
 	// 2. When creds are not provided, should get the creds from the store
 	t.Run("CredsNotProvidedTest", func(t *testing.T) {
 		rootParams.username = ""
 		rootParams.password = ""
-		getRegistryCredsFromStore(&csscParams, loginURL)
+		getRegistryCredsFromStore(&csscParams, common.TestLoginURL)
 		assert.Equal(t, "", csscParams.username)
 		assert.Equal(t, "", csscParams.password)
 	})
 }
-
-// Test appending element to a slice which does not contain the element. It should be appended.
-func TestAppendElement(t *testing.T) {
-
-	// 1. Should append the element to the slice when the slice does not contain the element
-	t.Run("AppendElementTest", func(t *testing.T) {
-		slice := []FilteredRepository{
-			{
-				Repository: csscTestRepo1,
-				Tag:        csscTestTag1,
-				PatchTag:   csscTestPatch1,
-			},
-		}
-		element := FilteredRepository{
-			Repository: csscTestRepo2,
-			Tag:        csscTestTag2,
-			PatchTag:   csscTestPatch2,
-		}
-		newSlice := appendElement(slice, element)
-		assert.Len(t, newSlice, 2)
-		assert.Equal(t, csscTestRepo1, newSlice[0].Repository)
-		assert.Equal(t, csscTestTag1, newSlice[0].Tag)
-		assert.Equal(t, csscTestPatch1, newSlice[0].PatchTag)
-		assert.Equal(t, csscTestRepo2, newSlice[1].Repository)
-		assert.Equal(t, csscTestTag2, newSlice[1].Tag)
-		assert.Equal(t, csscTestPatch2, newSlice[1].PatchTag)
-	})
-
-	// 2. Should not append the element to the slice when the slice already contains the element
-	t.Run("AppendElementAlreadyExistsTest", func(t *testing.T) {
-		slice := []FilteredRepository{
-			{
-				Repository: csscTestRepo1,
-				Tag:        csscTestTag1,
-				PatchTag:   csscTestPatch1,
-			},
-		}
-		element := FilteredRepository{
-			Repository: csscTestRepo1,
-			Tag:        csscTestTag1,
-			PatchTag:   csscTestPatch1,
-		}
-		newSlice := appendElement(slice, element)
-		assert.Len(t, newSlice, 1)
-		assert.Equal(t, csscTestRepo1, newSlice[0].Repository)
-		assert.Equal(t, csscTestTag1, newSlice[0].Tag)
-		assert.Equal(t, csscTestPatch1, newSlice[0].PatchTag)
-	})
-}
-
-// Helper function to create a pointer to a bool
-func boolPtr(v bool) *bool {
-	return &v
-}
-
-// All variables used in the tests
-var (
-	csscTestCtx      = context.Background()
-	csscTestRegistry = "registry"
-	csscTestRepo1    = "repo1"
-	csscTestRepo2    = "repo2"
-	csscTestRepo3    = "repo3"
-	csscTestRepo4    = "repo4"
-	csscTestTag1     = "tag1"
-	csscTestTag2     = "tag2"
-	csscTestPatch1   = "tag1-patched"
-	csscTestPatch2   = "tag2-patched"
-
-	CsscTestTagResult = &acr.RepositoryTagsType{
-		Response: autorest.Response{
-			Response: &http.Response{
-				StatusCode: 200,
-			},
-		},
-		Registry:  &csscTestRegistry,
-		ImageName: &csscTestRepo1,
-		TagsAttributes: &[]acr.TagAttributesBase{
-			{
-				Name: &csscTestTag1,
-			},
-			{
-				Name: &csscTestPatch1,
-			},
-			{
-				Name: &csscTestTag2,
-			},
-			{
-				Name: &csscTestPatch2,
-			},
-		},
-	}
-
-	CsscTestOneTagResult = &acr.RepositoryTagsType{
-		Response: autorest.Response{
-			Response: &http.Response{
-				StatusCode: 200,
-			},
-		},
-		Registry:  &csscTestRegistry,
-		ImageName: &csscTestRepo1,
-		TagsAttributes: &[]acr.TagAttributesBase{
-			{
-				Name: &csscTestTag1,
-			},
-		},
-	}
-)

--- a/cmd/acr/cssc_test.go
+++ b/cmd/acr/cssc_test.go
@@ -1,0 +1,382 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/Azure/acr-cli/acr"
+	"github.com/Azure/acr-cli/cmd/mocks"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestApplyFilterAndGetFilteredList(t *testing.T) {
+	mockAcrClient := &mocks.AcrCLIClientInterface{}
+
+	// 1. If filter contains only one repository and it is not specified, nothing will match the filter and an empty list should be returned
+	t.Run("RepositoryNotSpecifiedTest", func(t *testing.T) {
+		filter := Filter{
+			Version: "v1",
+			Repositories: []Repository{
+				{
+					Repository: "",
+					Tags:       []string{csscTestTag1, csscTestTag2},
+					Enabled:    boolPtr(true),
+				},
+			},
+		}
+
+		filteredRepositories, err := applyFilterAndGetFilteredList(context.Background(), mockAcrClient, filter)
+		assert.NoError(t, err)
+		assert.Nil(t, filteredRepositories)
+		assert.Len(t, filteredRepositories, 0)
+	})
+
+	//2.  If Tags are not specified for any repository in the filter, nothing will match the filter and an empty list should be returned
+	t.Run("TagsNotSpecifiedTest", func(t *testing.T) {
+		filter := Filter{
+			Version: "v1",
+			Repositories: []Repository{
+				{
+					Repository: csscTestRepo1,
+					Tags:       nil,
+					Enabled:    boolPtr(true),
+				},
+				{
+					Repository: csscTestRepo2,
+					Tags:       []string{""},
+					Enabled:    boolPtr(true),
+				},
+			},
+		}
+		filteredRepositories, err := applyFilterAndGetFilteredList(context.Background(), mockAcrClient, filter)
+		assert.NoError(t, err)
+		assert.Nil(t, filteredRepositories)
+		assert.Len(t, filteredRepositories, 0)
+	})
+
+	//3. Error should be returned when GetAcrTags fails for a repository
+	t.Run("GetAcrTagsFailsTest", func(t *testing.T) {
+		filter := Filter{
+			Version: "v1",
+			Repositories: []Repository{
+				{
+					Repository: csscTestRepo1,
+					Tags:       []string{csscTestTag1, csscTestTag2},
+					Enabled:    boolPtr(true),
+				},
+			},
+		}
+		mockAcrClient.On("GetAcrTags", csscTestCtx, csscTestRepo1, "", "").Return(nil, errors.New("failed getting the tags")).Once()
+		filteredRepositories, err := applyFilterAndGetFilteredList(context.Background(), mockAcrClient, filter)
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "failed getting the tags")
+		assert.Nil(t, filteredRepositories)
+	})
+
+	//4. If filter has a tag that doesn't exist in the repository, ignore it and return whatever exists that matches the filter
+	t.Run("TagSpecifiedInFilterDoesNotExistTest", func(t *testing.T) {
+		filter := Filter{
+			Version: "v1",
+			Repositories: []Repository{
+				{
+					Repository: csscTestRepo1,
+					Tags:       []string{csscTestTag1, csscTestTag2},
+					Enabled:    boolPtr(true),
+				},
+			},
+		}
+		mockAcrClient.On("GetAcrTags", csscTestCtx, csscTestRepo1, "", "").Return(CsscTestOneTagResult, nil).Once()
+		mockAcrClient.On("GetAcrTags", csscTestCtx, csscTestRepo1, "", csscTestTag1).Return(EmptyListTagsResult, nil).Once()
+
+		filteredRepositories, err := applyFilterAndGetFilteredList(context.Background(), mockAcrClient, filter)
+		assert.NoError(t, err)
+		assert.Len(t, filteredRepositories, 1) //
+		assert.Equal(t, csscTestRepo1, filteredRepositories[0].Repository)
+		assert.Equal(t, csscTestTag1, filteredRepositories[0].Tag)
+	})
+
+	// 5. Success scenario with all the combination of filters
+	t.Run("AllFilterCombinationTest", func(t *testing.T) {
+		filter := Filter{
+			Version: "v1",
+			Repositories: []Repository{
+				{
+					Repository: csscTestRepo1,
+					Tags:       []string{csscTestTag1, csscTestTag2}, // tags specified
+					Enabled:    boolPtr(true),
+				},
+				{
+					Repository: csscTestRepo2,
+					Tags:       []string{"*"}, // * all tags
+					Enabled:    boolPtr(true),
+				},
+				{
+					Repository: csscTestRepo3,
+					Tags:       []string{csscTestTag1, csscTestTag2},
+					Enabled:    nil, // nil means enabled
+				},
+				{
+					Repository: csscTestRepo4,
+					Tags:       []string{csscTestTag1, csscTestTag2},
+					Enabled:    boolPtr(false), // disabled repository for all tags
+				},
+			},
+		}
+		mockAcrClient.On("GetAcrTags", csscTestCtx, csscTestRepo1, "", "").Return(CsscTestTagResult, nil).Once()
+		mockAcrClient.On("GetAcrTags", csscTestCtx, csscTestRepo1, "", csscTestPatch2).Return(EmptyListTagsResult, nil).Once()
+		mockAcrClient.On("GetAcrTags", csscTestCtx, csscTestRepo2, "", "").Return(CsscTestTagResult, nil).Once()
+		mockAcrClient.On("GetAcrTags", csscTestCtx, csscTestRepo2, "", csscTestPatch2).Return(EmptyListTagsResult, nil).Once()
+		mockAcrClient.On("GetAcrTags", csscTestCtx, csscTestRepo3, "", "").Return(CsscTestTagResult, nil).Once()
+		mockAcrClient.On("GetAcrTags", csscTestCtx, csscTestRepo3, "", csscTestPatch2).Return(EmptyListTagsResult, nil).Once()
+		mockAcrClient.On("GetAcrTags", csscTestCtx, csscTestRepo4, "", "").Return(CsscTestTagResult, nil).Once()
+		mockAcrClient.On("GetAcrTags", csscTestCtx, csscTestRepo4, "", csscTestPatch2).Return(EmptyListTagsResult, nil).Once()
+
+		filteredRepositories, err := applyFilterAndGetFilteredList(context.Background(), mockAcrClient, filter)
+		assert.NoError(t, err)
+		assert.Len(t, filteredRepositories, 6)
+		assert.Equal(t, csscTestRepo1, filteredRepositories[0].Repository)
+		assert.Equal(t, csscTestTag1, filteredRepositories[0].Tag)
+		assert.Equal(t, csscTestPatch1, filteredRepositories[0].PatchTag)
+		assert.Equal(t, csscTestRepo1, filteredRepositories[1].Repository)
+		assert.Equal(t, csscTestTag2, filteredRepositories[1].Tag)
+		assert.Equal(t, csscTestPatch2, filteredRepositories[1].PatchTag)
+
+		assert.Equal(t, csscTestRepo2, filteredRepositories[2].Repository)
+		assert.Equal(t, csscTestTag1, filteredRepositories[2].Tag)
+		assert.Equal(t, csscTestPatch1, filteredRepositories[2].PatchTag)
+		assert.Equal(t, csscTestRepo2, filteredRepositories[3].Repository)
+		assert.Equal(t, csscTestTag2, filteredRepositories[3].Tag)
+		assert.Equal(t, csscTestPatch2, filteredRepositories[3].PatchTag)
+
+		assert.Equal(t, csscTestRepo3, filteredRepositories[4].Repository)
+		assert.Equal(t, csscTestTag1, filteredRepositories[4].Tag)
+		assert.Equal(t, csscTestPatch1, filteredRepositories[4].PatchTag)
+		assert.Equal(t, csscTestRepo3, filteredRepositories[5].Repository)
+		assert.Equal(t, csscTestTag2, filteredRepositories[5].Tag)
+		assert.Equal(t, csscTestPatch2, filteredRepositories[5].PatchTag)
+	})
+}
+
+func TestGetFilterFromFilterPolicy(t *testing.T) {
+	rootParams := &rootParameters{}
+	rootParams.username = "username"
+	rootParams.password = "password"
+	csscParams := csscParameters{rootParameters: rootParams}
+	loginURL := testLoginURL
+
+	//1. Error should be returned when filter policy is not in the correct format
+	t.Run("FilterPolicyNotCorrectFormatTest", func(t *testing.T) {
+		csscParams.filterPolicy = "notcorrectformat"
+		filter, err := getFilterFromFilterPolicy(context.Background(), &csscParams, loginURL)
+		assert.NotEqual(nil, err, "Error should not be nil")
+		assert.Equal(t, "filter-policy should be in the format repo:tag", err.Error())
+		assert.Equal(t, Filter{}, filter)
+	})
+
+	//2. Error should be returned when fetching repository manifest fails
+	t.Run("FetchBytesFailsTest", func(t *testing.T) {
+		csscParams.filterPolicy = "repo1:tag1"
+		filter, err := getFilterFromFilterPolicy(context.Background(), &csscParams, loginURL)
+		assert.NotEqual(nil, err, "Error should not be nil")
+		assert.ErrorContains(t, err, "error fetching manifest content when reading the filter policy")
+		assert.Equal(t, Filter{}, filter)
+	})
+}
+
+func TestGetFilterFromFilePath(t *testing.T) {
+
+	//1. Error should be returned when filter file does not exist
+	t.Run("FileDoesNotExistTest", func(t *testing.T) {
+		filter, err := getFilterFromFilePath("idontexist")
+		assert.NotEqual(nil, err, "Error should not be nil")
+		assert.ErrorContains(t, err, "error reading the filter json file from file path")
+		assert.Equal(t, Filter{}, filter)
+	})
+
+	//2. Error should be returned when filter file is not in the correct format
+	t.Run("FileNotCorrectFormatTest", func(t *testing.T) {
+		var filterFile = []byte(`i am not a json file`)
+		err := os.WriteFile("filter-wrongformat.json", filterFile, 0600)
+
+		assert.Nil(t, err, "Error should be nil")
+		filter, err := getFilterFromFilePath("filter-wrongformat.json")
+		assert.NotEqual(nil, err, "Error should not be nil")
+		assert.ErrorContains(t, err, "error unmarshalling json content when reading the filter file from file path")
+		assert.Equal(t, Filter{}, filter)
+
+		err = os.Remove("filter-wrongformat.json")
+		assert.Nil(t, err, "Error should be nil")
+	})
+
+	//3. Success scenario with correct filter file
+	t.Run("SuccessTest", func(t *testing.T) {
+		var filterFile = []byte(`{
+			"version": "v1",
+			"repositories": [
+				{
+					"repository": "repo1",
+					"tags": ["tag1", "tag2"],
+					"enabled": true
+				},
+				{
+					"repository": "repo2",
+					"tags": ["tag1"],
+					"enabled": true
+				}
+			]
+		}`)
+		err := os.WriteFile("filter.json", filterFile, 0600)
+		assert.Nil(t, err, "Error should be nil")
+
+		filter, err := getFilterFromFilePath("filter.json")
+		assert.Nil(t, err, "Error should be nil")
+		assert.Equal(t, "v1", filter.Version)
+		assert.Len(t, filter.Repositories, 2)
+		assert.Equal(t, csscTestRepo1, filter.Repositories[0].Repository)
+		assert.Equal(t, csscTestTag1, filter.Repositories[0].Tags[0])
+		assert.Equal(t, csscTestTag2, filter.Repositories[0].Tags[1])
+		assert.Equal(t, true, *filter.Repositories[0].Enabled)
+		assert.Equal(t, csscTestRepo2, filter.Repositories[1].Repository)
+		assert.Equal(t, csscTestTag1, filter.Repositories[1].Tags[0])
+		assert.Equal(t, true, *filter.Repositories[1].Enabled)
+
+		err = os.Remove("filter.json")
+		assert.Nil(t, err, "Error should be nil")
+	})
+}
+
+func TestGetRegistryCredsFromStore(t *testing.T) {
+	rootParams := &rootParameters{}
+	rootParams.configs = []string{"config1", "config2"}
+	csscParams := csscParameters{rootParameters: rootParams}
+	loginURL := testLoginURL
+
+	// 1. Should not get the creds from the store when creds are provided
+	t.Run("CredsProvidedTest", func(t *testing.T) {
+		rootParams.username = "username"
+		rootParams.password = "password"
+		getRegistryCredsFromStore(&csscParams, loginURL)
+		assert.Equal(t, "username", csscParams.username)
+		assert.Equal(t, "password", csscParams.password)
+	})
+
+	// 2. When creds are not provided, should get the creds from the store
+	t.Run("CredsNotProvidedTest", func(t *testing.T) {
+		rootParams.username = ""
+		rootParams.password = ""
+		getRegistryCredsFromStore(&csscParams, loginURL)
+		assert.Equal(t, "", csscParams.username)
+		assert.Equal(t, "", csscParams.password)
+	})
+}
+
+// Test appending element to a slice which does not contain the element. It should be appended.
+func TestAppendElement(t *testing.T) {
+
+	// 1. Should append the element to the slice when the slice does not contain the element
+	t.Run("AppendElementTest", func(t *testing.T) {
+		slice := []FilteredRepository{
+			{
+				Repository: csscTestRepo1,
+				Tag:        csscTestTag1,
+				PatchTag:   csscTestPatch1,
+			},
+		}
+		element := FilteredRepository{
+			Repository: csscTestRepo2,
+			Tag:        csscTestTag2,
+			PatchTag:   csscTestPatch2,
+		}
+		newSlice := appendElement(slice, element)
+		assert.Len(t, newSlice, 2)
+		assert.Equal(t, csscTestRepo1, newSlice[0].Repository)
+		assert.Equal(t, csscTestTag1, newSlice[0].Tag)
+		assert.Equal(t, csscTestPatch1, newSlice[0].PatchTag)
+		assert.Equal(t, csscTestRepo2, newSlice[1].Repository)
+		assert.Equal(t, csscTestTag2, newSlice[1].Tag)
+		assert.Equal(t, csscTestPatch2, newSlice[1].PatchTag)
+	})
+
+	// 2. Should not append the element to the slice when the slice already contains the element
+	t.Run("AppendElementAlreadyExistsTest", func(t *testing.T) {
+		slice := []FilteredRepository{
+			{
+				Repository: csscTestRepo1,
+				Tag:        csscTestTag1,
+				PatchTag:   csscTestPatch1,
+			},
+		}
+		element := FilteredRepository{
+			Repository: csscTestRepo1,
+			Tag:        csscTestTag1,
+			PatchTag:   csscTestPatch1,
+		}
+		newSlice := appendElement(slice, element)
+		assert.Len(t, newSlice, 1)
+		assert.Equal(t, csscTestRepo1, newSlice[0].Repository)
+		assert.Equal(t, csscTestTag1, newSlice[0].Tag)
+		assert.Equal(t, csscTestPatch1, newSlice[0].PatchTag)
+	})
+}
+
+// Helper function to create a pointer to a bool
+func boolPtr(v bool) *bool {
+	return &v
+}
+
+// All variables used in the tests
+var (
+	csscTestCtx      = context.Background()
+	csscTestRegistry = "registry"
+	csscTestRepo1    = "repo1"
+	csscTestRepo2    = "repo2"
+	csscTestRepo3    = "repo3"
+	csscTestRepo4    = "repo4"
+	csscTestTag1     = "tag1"
+	csscTestTag2     = "tag2"
+	csscTestPatch1   = "tag1-patched"
+	csscTestPatch2   = "tag2-patched"
+
+	CsscTestTagResult = &acr.RepositoryTagsType{
+		Response: autorest.Response{
+			Response: &http.Response{
+				StatusCode: 200,
+			},
+		},
+		Registry:  &csscTestRegistry,
+		ImageName: &csscTestRepo1,
+		TagsAttributes: &[]acr.TagAttributesBase{
+			{
+				Name: &csscTestTag1,
+			},
+			{
+				Name: &csscTestPatch1,
+			},
+			{
+				Name: &csscTestTag2,
+			},
+			{
+				Name: &csscTestPatch2,
+			},
+		},
+	}
+
+	CsscTestOneTagResult = &acr.RepositoryTagsType{
+		Response: autorest.Response{
+			Response: &http.Response{
+				StatusCode: 200,
+			},
+		},
+		Registry:  &csscTestRegistry,
+		ImageName: &csscTestRepo1,
+		TagsAttributes: &[]acr.TagAttributesBase{
+			{
+				Name: &csscTestTag1,
+			},
+		},
+	}
+)

--- a/cmd/acr/cssc_test.go
+++ b/cmd/acr/cssc_test.go
@@ -35,7 +35,7 @@ func TestGetRegistryCredsFromStore(t *testing.T) {
 	t.Run("CredsProvidedTest", func(t *testing.T) {
 		rootParams.username = "username"
 		rootParams.password = "password"
-		getRegistryCredsFromStore(&csscParams, common.TestLoginURL)
+		resolveRegistryCredentials(&csscParams, common.TestLoginURL)
 		assert.Equal(t, "username", csscParams.username)
 		assert.Equal(t, "password", csscParams.password)
 	})
@@ -43,7 +43,7 @@ func TestGetRegistryCredsFromStore(t *testing.T) {
 	t.Run("CredsNotProvidedTest", func(t *testing.T) {
 		rootParams.username = ""
 		rootParams.password = ""
-		getRegistryCredsFromStore(&csscParams, common.TestLoginURL)
+		resolveRegistryCredentials(&csscParams, common.TestLoginURL)
 		assert.Equal(t, "", csscParams.username)
 		assert.Equal(t, "", csscParams.password)
 	})

--- a/cmd/acr/root.go
+++ b/cmd/acr/root.go
@@ -39,6 +39,7 @@ To start working with the CLI, run acr --help`,
 		newLogoutCmd(),
 		newTagCmd(&rootParams),
 		newManifestCmd(&rootParams),
+		newCsscCmd(&rootParams),
 	)
 	cmd.PersistentFlags().StringVarP(&rootParams.registryName, "registry", "r", "", "Registry name")
 	cmd.PersistentFlags().StringVarP(&rootParams.username, "username", "u", "", "Registry username")

--- a/cmd/acr/tag.go
+++ b/cmd/acr/tag.go
@@ -7,9 +7,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/Azure/acr-cli/acr"
 	"github.com/Azure/acr-cli/cmd/api"
-	"github.com/pkg/errors"
+	"github.com/Azure/acr-cli/internal/tag"
 	"github.com/spf13/cobra"
 )
 
@@ -72,7 +71,7 @@ func newTagListCmd(tagParams *tagParameters) *cobra.Command {
 				return err
 			}
 			ctx := context.Background()
-			tagList, err := listTags(ctx, acrClient, tagParams.repoName)
+			tagList, err := tag.ListTags(ctx, acrClient, tagParams.repoName)
 			if err != nil {
 				return err
 			}
@@ -85,38 +84,6 @@ func newTagListCmd(tagParams *tagParameters) *cobra.Command {
 		},
 	}
 	return cmd
-}
-
-// listTags will do the http requests and return the digest of all the tags in the selected repository.
-func listTags(ctx context.Context, acrClient api.AcrCLIClientInterface, repoName string) ([]acr.TagAttributesBase, error) {
-
-	lastTag := ""
-	resultTags, err := acrClient.GetAcrTags(ctx, repoName, "", lastTag)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to list tags")
-	}
-
-	var tagList []acr.TagAttributesBase
-	tagList = append(tagList, *resultTags.TagsAttributes...)
-
-	// A for loop is used because the GetAcrTags method returns by default only 100 tags and their attributes.
-	for resultTags != nil && resultTags.TagsAttributes != nil {
-		tags := *resultTags.TagsAttributes
-
-		// Since the GetAcrTags supports pagination when supplied with the last digest that was returned the last tag name
-		// digest is saved, the tag array contains at least one element because if it was empty the API would return
-		// a nil pointer instead of a pointer to a length 0 array.
-		lastTag = *tags[len(tags)-1].Name
-		resultTags, err = acrClient.GetAcrTags(ctx, repoName, "", lastTag)
-		if err != nil {
-			return nil, err
-		}
-		if resultTags != nil && resultTags.TagsAttributes != nil {
-			tagList = append(tagList, *resultTags.TagsAttributes...)
-		}
-	}
-
-	return tagList, nil
 }
 
 // newTagDeleteCmd defines the tag delete subcommand, it receives as an argument an array of tag digests.
@@ -137,7 +104,7 @@ func newTagDeleteCmd(tagParams *tagParameters) *cobra.Command {
 				return err
 			}
 			ctx := context.Background()
-			err = deleteTags(ctx, acrClient, loginURL, tagParams.repoName, args)
+			err = tag.DeleteTags(ctx, acrClient, loginURL, tagParams.repoName, args)
 			if err != nil {
 				return err
 			}
@@ -146,17 +113,4 @@ func newTagDeleteCmd(tagParams *tagParameters) *cobra.Command {
 	}
 
 	return cmd
-}
-
-// deleteTags receives an array of tags digest and deletes them using the supplied acrClient.
-func deleteTags(ctx context.Context, acrClient api.AcrCLIClientInterface, loginURL string, repoName string, args []string) error {
-	for i := 0; i < len(args); i++ {
-		_, err := acrClient.DeleteAcrTag(ctx, repoName, args[i])
-		if err != nil {
-			// If there is an error (this includes not found and not allowed operations) the deletion of the tags is stopped and an error is returned.
-			return errors.Wrap(err, "failed to delete tags")
-		}
-		fmt.Printf("%s/%s:%s\n", loginURL, repoName, args[i])
-	}
-	return nil
 }

--- a/cmd/acr/tag.go
+++ b/cmd/acr/tag.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/Azure/acr-cli/cmd/api"
+	"github.com/Azure/acr-cli/internal/api"
 	"github.com/Azure/acr-cli/internal/tag"
 	"github.com/spf13/cobra"
 )

--- a/cmd/acr/tag_test.go
+++ b/cmd/acr/tag_test.go
@@ -17,8 +17,9 @@ func TestListTags(t *testing.T) {
 		assert := assert.New(t)
 		mockClient := &mocks.AcrCLIClientInterface{}
 		mockClient.On("GetAcrTags", testCtx, testRepo, "", "").Return(notFoundTagResponse, errors.New("testRepo not found")).Once()
-		err := listTags(testCtx, mockClient, testLoginURL, testRepo)
+		tagList, err := listTags(testCtx, mockClient, testRepo)
 		assert.NotEqual(nil, err, "Error should not be nil")
+		assert.Equal(0, len(tagList), "Tag list should be empty")
 		mockClient.AssertExpectations(t)
 	})
 	// Second test, if an error is returned on any GetAcrTags call an error should be returned.
@@ -27,7 +28,8 @@ func TestListTags(t *testing.T) {
 		mockClient := &mocks.AcrCLIClientInterface{}
 		mockClient.On("GetAcrTags", testCtx, testRepo, "", "").Return(OneTagResult, nil).Once()
 		mockClient.On("GetAcrTags", testCtx, testRepo, "", "latest").Return(nil, errors.New("unauthorized")).Once()
-		err := listTags(testCtx, mockClient, testLoginURL, testRepo)
+		tagList, err := listTags(testCtx, mockClient, testRepo)
+		assert.Equal(0, len(tagList), "Tag list should be empty")
 		assert.NotEqual(nil, err, "Error should not be nil")
 		mockClient.AssertExpectations(t)
 	})
@@ -38,8 +40,9 @@ func TestListTags(t *testing.T) {
 		mockClient.On("GetAcrTags", testCtx, testRepo, "", "").Return(OneTagResult, nil).Once()
 		mockClient.On("GetAcrTags", testCtx, testRepo, "", "latest").Return(FourTagsResult, nil).Once()
 		mockClient.On("GetAcrTags", testCtx, testRepo, "", "v4").Return(EmptyListTagsResult, nil).Once()
-		err := listTags(testCtx, mockClient, testLoginURL, testRepo)
+		tagList, err := listTags(testCtx, mockClient, testRepo)
 		assert.Equal(nil, err, "Error should be nil")
+		assert.Equal(5, len(tagList), "Tag list should have 5 tags")
 		mockClient.AssertExpectations(t)
 	})
 }

--- a/cmd/acr/tag_test.go
+++ b/cmd/acr/tag_test.go
@@ -4,71 +4,33 @@
 package main
 
 import (
-	"errors"
 	"testing"
 
-	"github.com/Azure/acr-cli/cmd/mocks"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestListTags(t *testing.T) {
-	// First test, repository not found should return an error.
-	t.Run("RepositoryNotFoundTest", func(t *testing.T) {
-		assert := assert.New(t)
-		mockClient := &mocks.AcrCLIClientInterface{}
-		mockClient.On("GetAcrTags", testCtx, testRepo, "", "").Return(notFoundTagResponse, errors.New("testRepo not found")).Once()
-		tagList, err := listTags(testCtx, mockClient, testRepo)
-		assert.NotEqual(nil, err, "Error should not be nil")
-		assert.Equal(0, len(tagList), "Tag list should be empty")
-		mockClient.AssertExpectations(t)
-	})
-	// Second test, if an error is returned on any GetAcrTags call an error should be returned.
-	t.Run("ErrorOnSecondPageTest", func(t *testing.T) {
-		assert := assert.New(t)
-		mockClient := &mocks.AcrCLIClientInterface{}
-		mockClient.On("GetAcrTags", testCtx, testRepo, "", "").Return(OneTagResult, nil).Once()
-		mockClient.On("GetAcrTags", testCtx, testRepo, "", "latest").Return(nil, errors.New("unauthorized")).Once()
-		tagList, err := listTags(testCtx, mockClient, testRepo)
-		assert.Equal(0, len(tagList), "Tag list should be empty")
-		assert.NotEqual(nil, err, "Error should not be nil")
-		mockClient.AssertExpectations(t)
-	})
-	// Third test, no errors
-	t.Run("ListFiveTagsTest", func(t *testing.T) {
-		assert := assert.New(t)
-		mockClient := &mocks.AcrCLIClientInterface{}
-		mockClient.On("GetAcrTags", testCtx, testRepo, "", "").Return(OneTagResult, nil).Once()
-		mockClient.On("GetAcrTags", testCtx, testRepo, "", "latest").Return(FourTagsResult, nil).Once()
-		mockClient.On("GetAcrTags", testCtx, testRepo, "", "v4").Return(EmptyListTagsResult, nil).Once()
-		tagList, err := listTags(testCtx, mockClient, testRepo)
-		assert.Equal(nil, err, "Error should be nil")
-		assert.Equal(5, len(tagList), "Tag list should have 5 tags")
-		mockClient.AssertExpectations(t)
-	})
+func TestNewTagCmd(t *testing.T) {
+	rootParams := &rootParameters{}
+	cmd := newTagCmd(rootParams)
+	assert.NotNil(t, cmd)
+	assert.Equal(t, "tag", cmd.Use)
+	assert.Equal(t, newTagCmdLongMessage, cmd.Long)
 }
 
-func TestDeleteTags(t *testing.T) {
-	args := []string{"latest", "v1", "v2", "v3", "v4"}
-	// First test, tag not found should return an error.
-	t.Run("TagNotFoundTest", func(t *testing.T) {
-		assert := assert.New(t)
-		mockClient := &mocks.AcrCLIClientInterface{}
-		mockClient.On("DeleteAcrTag", testCtx, testRepo, "latest").Return(&notFoundResponse, errors.New("not found")).Once()
-		err := deleteTags(testCtx, mockClient, testLoginURL, testRepo, args)
-		assert.NotEqual(nil, err, "Error should not be nil")
-		mockClient.AssertExpectations(t)
-	})
-	// Second test, five tags deleted, regular behavior
-	t.Run("DeleteFiveTagsTest", func(t *testing.T) {
-		assert := assert.New(t)
-		mockClient := &mocks.AcrCLIClientInterface{}
-		mockClient.On("DeleteAcrTag", testCtx, testRepo, "latest").Return(&deletedResponse, nil).Once()
-		mockClient.On("DeleteAcrTag", testCtx, testRepo, "v1").Return(&deletedResponse, nil).Once()
-		mockClient.On("DeleteAcrTag", testCtx, testRepo, "v2").Return(&deletedResponse, nil).Once()
-		mockClient.On("DeleteAcrTag", testCtx, testRepo, "v3").Return(&deletedResponse, nil).Once()
-		mockClient.On("DeleteAcrTag", testCtx, testRepo, "v4").Return(&deletedResponse, nil).Once()
-		err := deleteTags(testCtx, mockClient, testLoginURL, testRepo, args)
-		assert.Equal(nil, err, "Error should be nil")
-		mockClient.AssertExpectations(t)
-	})
+func TestNewTagListCmd(t *testing.T) {
+	rootParams := &rootParameters{}
+	tagParams := tagParameters{rootParameters: rootParams}
+	cmd := newTagListCmd(&tagParams)
+	assert.NotNil(t, cmd)
+	assert.Equal(t, "list", cmd.Use)
+	assert.Equal(t, newTagListCmdLongMessage, cmd.Long)
+}
+
+func TestNewTagDeleteCmd(t *testing.T) {
+	rootParams := &rootParameters{}
+	tagParams := tagParameters{rootParameters: rootParams}
+	cmd := newTagDeleteCmd(&tagParams)
+	assert.NotNil(t, cmd)
+	assert.Equal(t, "delete", cmd.Use)
+	assert.Equal(t, newTagDeleteCmdLongMessage, cmd.Long)
 }

--- a/internal/common/testhelper.go
+++ b/internal/common/testhelper.go
@@ -1,0 +1,137 @@
+package common
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/Azure/acr-cli/acr"
+	"github.com/Azure/go-autorest/autorest"
+)
+
+var (
+	TestCtx      = context.Background()
+	TestLoginURL = "foo.azurecr.io"
+	TestRepo     = "bar"
+
+	TagName         = "latest"
+	TagName1        = "v1"
+	TagName2        = "v2"
+	TagName3        = "v3"
+	TagName4        = "v4"
+	TagNamePatch1   = "v1-patched"
+	TagNamePatch2   = "v2-patched"
+	RepoName1       = "repo1"
+	RepoName2       = "repo2"
+	RepoName3       = "repo3"
+	RepoName4       = "repo4"
+	deleteEnabled   = true
+	lastUpdateTime  = time.Now().Add(-15 * time.Minute).UTC().Format(time.RFC3339Nano)
+	writeEnabled    = true
+	digest          = "sha256:2830cc0fcddc1bc2bd4aeab0ed5ee7087dab29a49e65151c77553e46a7ed5283" //#nosec G101
+	multiArchDigest = "sha256:d88fb54ba4424dada7c928c6af332ed1c49065ad85eafefb6f26664695015119" //#nosec G101
+
+	NotFoundResponse = autorest.Response{
+		Response: &http.Response{
+			StatusCode: 404,
+		},
+	}
+	DeletedResponse = autorest.Response{
+		Response: &http.Response{
+			StatusCode: 200,
+		},
+	}
+
+	// Response for the GetAcrTags when the repository is not found.
+	NotFoundTagResponse = &acr.RepositoryTagsType{
+		Response: NotFoundResponse,
+	}
+
+	// Response for the GetAcrTags when there are no tags on the testRepo.
+	EmptyListTagsResult = &acr.RepositoryTagsType{
+		Registry:       &TestLoginURL,
+		ImageName:      &TestRepo,
+		TagsAttributes: nil,
+	}
+
+	// Response for the GetAcrTags when there is one tag on the testRepo.
+	OneTagResult = &acr.RepositoryTagsType{
+		Response: autorest.Response{
+			Response: &http.Response{
+				StatusCode: 200,
+			},
+		},
+		Registry:  &TestLoginURL,
+		ImageName: &TestRepo,
+		TagsAttributes: &[]acr.TagAttributesBase{
+			{
+				Name:                 &TagName,
+				LastUpdateTime:       &lastUpdateTime,
+				ChangeableAttributes: &acr.ChangeableAttributes{DeleteEnabled: &deleteEnabled, WriteEnabled: &writeEnabled},
+				Digest:               &digest,
+			},
+		},
+	}
+
+	FourTagsResult = &acr.RepositoryTagsType{
+		Response: autorest.Response{
+			Response: &http.Response{
+				StatusCode: 200,
+			},
+		},
+		Registry:  &TestLoginURL,
+		ImageName: &TestRepo,
+		TagsAttributes: &[]acr.TagAttributesBase{{
+			Name:                 &TagName1,
+			LastUpdateTime:       &lastUpdateTime,
+			ChangeableAttributes: &acr.ChangeableAttributes{DeleteEnabled: &deleteEnabled, WriteEnabled: &writeEnabled},
+			Digest:               &digest,
+		}, {
+			Name:                 &TagName2,
+			LastUpdateTime:       &lastUpdateTime,
+			ChangeableAttributes: &acr.ChangeableAttributes{DeleteEnabled: &deleteEnabled, WriteEnabled: &writeEnabled},
+			Digest:               &digest,
+		}, {
+			Name:                 &TagName3,
+			LastUpdateTime:       &lastUpdateTime,
+			ChangeableAttributes: &acr.ChangeableAttributes{DeleteEnabled: &deleteEnabled, WriteEnabled: &writeEnabled},
+			Digest:               &multiArchDigest,
+		}, {
+			Name:                 &TagName4,
+			LastUpdateTime:       &lastUpdateTime,
+			ChangeableAttributes: &acr.ChangeableAttributes{DeleteEnabled: &deleteEnabled, WriteEnabled: &writeEnabled},
+			Digest:               &digest,
+		}},
+	}
+
+	FourTagResultWithPatchTags = &acr.RepositoryTagsType{
+		Response: autorest.Response{
+			Response: &http.Response{
+				StatusCode: 200,
+			},
+		},
+		Registry:  &TestLoginURL,
+		ImageName: &TestRepo,
+		TagsAttributes: &[]acr.TagAttributesBase{{
+			Name:                 &TagName1,
+			LastUpdateTime:       &lastUpdateTime,
+			ChangeableAttributes: &acr.ChangeableAttributes{DeleteEnabled: &deleteEnabled, WriteEnabled: &writeEnabled},
+			Digest:               &digest,
+		}, {
+			Name:                 &TagNamePatch1,
+			LastUpdateTime:       &lastUpdateTime,
+			ChangeableAttributes: &acr.ChangeableAttributes{DeleteEnabled: &deleteEnabled, WriteEnabled: &writeEnabled},
+			Digest:               &digest,
+		}, {
+			Name:                 &TagName2,
+			LastUpdateTime:       &lastUpdateTime,
+			ChangeableAttributes: &acr.ChangeableAttributes{DeleteEnabled: &deleteEnabled, WriteEnabled: &writeEnabled},
+			Digest:               &digest,
+		}, {
+			Name:                 &TagNamePatch2,
+			LastUpdateTime:       &lastUpdateTime,
+			ChangeableAttributes: &acr.ChangeableAttributes{DeleteEnabled: &deleteEnabled, WriteEnabled: &writeEnabled},
+			Digest:               &digest,
+		}},
+	}
+)

--- a/internal/cssc/cssc.go
+++ b/internal/cssc/cssc.go
@@ -1,0 +1,190 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cssc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/Azure/acr-cli/internal/tag"
+
+	"github.com/Azure/acr-cli/cmd/api"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+
+	oras "oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/content"
+	"oras.land/oras-go/v2/registry/remote"
+	"oras.land/oras-go/v2/registry/remote/auth"
+	"oras.land/oras-go/v2/registry/remote/retry"
+)
+
+// Filter struct to hold the filter policy
+type Filter struct {
+	Version      string       `json:"version"`
+	Repositories []Repository `json:"repositories"`
+}
+
+type Repository struct {
+	Repository string   `json:"repository"`
+	Tags       []string `json:"tags"`
+	Enabled    *bool    `json:"enabled"`
+}
+
+// Repository struct to hold the filtered repository, tag and patch tag if any
+type FilteredRepository struct {
+	Repository string
+	Tag        string
+	PatchTag   string
+}
+
+// Reads the filter policy from the specified repository and tag and returns the Filter struct
+func GetFilterFromFilterPolicy(ctx context.Context, filterPolicy string, loginURL string, username string, password string) (Filter, error) {
+	if !strings.Contains(filterPolicy, ":") {
+		return Filter{}, errors.New("filter-policy should be in the format repo:tag")
+	}
+	repoTag := strings.Split(filterPolicy, ":")
+	filterRepoName := repoTag[0]
+	filterRepoTagName := repoTag[1]
+
+	// Connect to the remote repository
+	repo, err := remote.NewRepository(fmt.Sprintf("%s/%s", loginURL, filterRepoName))
+	if err != nil {
+		panic(err)
+	}
+	repo.Client = &auth.Client{
+		Client: retry.DefaultClient,
+		Cache:  auth.NewCache(),
+		Credential: auth.StaticCredential(loginURL, auth.Credential{
+			Username: username,
+			Password: password,
+		}),
+	}
+
+	// Get manifest and read content
+	_, pulledManifestContent, err := oras.FetchBytes(ctx, repo, filterRepoTagName, oras.DefaultFetchBytesOptions)
+	if err != nil {
+		return Filter{}, errors.Wrap(err, "error fetching manifest content when reading the filter policy")
+	}
+	var pulledManifest v1.Manifest
+	if err := json.Unmarshal(pulledManifestContent, &pulledManifest); err != nil {
+		panic(err)
+	}
+	var fileContent []byte
+	for _, layer := range pulledManifest.Layers {
+		fileContent, err = content.FetchAll(ctx, repo, layer)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	// Unmarshal the JSON file data to Filter struct
+	var filter = Filter{}
+	if err := json.Unmarshal(fileContent, &filter); err != nil {
+		return Filter{}, errors.Wrap(err, "error unmarshalling json content when reading the filter policy")
+	}
+	return filter, nil
+}
+
+// Reads the filter json from the specified file path and returns the Filter struct
+func GetFilterFromFilePath(filePath string) (Filter, error) {
+	file, err := os.ReadFile(filePath)
+	if err != nil {
+		return Filter{}, errors.Wrap(err, "error reading the filter json file from file path")
+	}
+
+	var filter = Filter{}
+	if err := json.Unmarshal(file, &filter); err != nil {
+		return Filter{}, errors.Wrap(err, "error unmarshalling json content when reading the filter file from file path")
+	}
+
+	return filter, nil
+}
+
+// Applies filter to filter out the repositories and tags from the ACR according to the specified criteria and returns the FilteredRepository struct
+func ApplyFilterAndGetFilteredList(ctx context.Context, acrClient api.AcrCLIClientInterface, filter Filter) ([]FilteredRepository, error) {
+	var filteredRepos []FilteredRepository
+
+	for _, filterRepo := range filter.Repositories {
+		if filterRepo.Enabled != nil && !*filterRepo.Enabled {
+			continue
+		}
+		if filterRepo.Repository == "" || filterRepo.Tags == nil || len(filterRepo.Tags) == 0 || filterRepo.Tags[0] == "" {
+			continue
+		}
+
+		tagList, err := tag.ListTags(ctx, acrClient, filterRepo.Repository)
+		if err != nil {
+			if strings.Contains(err.Error(), "404") {
+				continue
+			}
+			return nil, err
+		}
+
+		if len(filterRepo.Tags) == 1 && filterRepo.Tags[0] == "*" {
+			for _, tag := range tagList {
+				if strings.Contains(*tag.Name, "-patched") {
+					originalTag := strings.Split(*tag.Name, "-patched")[0]
+					matchingRepo := FilteredRepository{Repository: filterRepo.Repository, Tag: originalTag, PatchTag: *tag.Name}
+					filteredRepos = AppendElement(filteredRepos, matchingRepo)
+				} else {
+					matchingRepo := FilteredRepository{Repository: filterRepo.Repository, Tag: *tag.Name, PatchTag: *tag.Name}
+					filteredRepos = AppendElement(filteredRepos, matchingRepo)
+				}
+			}
+		} else {
+			for _, ftag := range filterRepo.Tags {
+				for _, tag := range tagList {
+					if *tag.Name == ftag {
+						matchingRepo := FilteredRepository{Repository: filterRepo.Repository, Tag: *tag.Name, PatchTag: *tag.Name}
+						filteredRepos = AppendElement(filteredRepos, matchingRepo)
+					} else if *tag.Name == ftag+"-patched" {
+						matchingRepo := FilteredRepository{Repository: filterRepo.Repository, Tag: ftag, PatchTag: ftag + "-patched"}
+						filteredRepos = AppendElement(filteredRepos, matchingRepo)
+					}
+				}
+			}
+		}
+	}
+	return filteredRepos, nil
+}
+
+// Prints the filtered result to the console
+func PrintFilteredResult(filteredResult []FilteredRepository, showPatchTags bool, loginURL string) {
+	if len(filteredResult) == 0 {
+		fmt.Println("No matching repository and tag found!")
+	}
+	if showPatchTags {
+		fmt.Println("Listing repositories and tags matching the filter with corrosponding patch tag (if present):")
+		for _, result := range filteredResult {
+			fmt.Printf("%s/%s:%s,%s\n", loginURL, result.Repository, result.Tag, result.PatchTag)
+		}
+	} else {
+		fmt.Println("Listing repositories and tags matching the filter:")
+		for _, result := range filteredResult {
+			fmt.Printf("%s/%s:%s\n", loginURL, result.Repository, result.Tag)
+		}
+	}
+	fmt.Println("Total matches found:", len(filteredResult))
+}
+
+// Appends the element to the slice if it does not already exist in the slice
+func AppendElement(slice []FilteredRepository, element FilteredRepository) []FilteredRepository {
+	for _, existing := range slice {
+		if existing.Repository == element.Repository && existing.Tag == element.Tag {
+			// Remove the existing element from the slice
+			for i, v := range slice {
+				if v.Repository == element.Repository && v.Tag == element.Tag {
+					slice = append(slice[:i], slice[i+1:]...)
+					break
+				}
+			}
+		}
+	}
+	// Append the new element to the slice
+	return append(slice, element)
+}

--- a/internal/cssc/cssc.go
+++ b/internal/cssc/cssc.go
@@ -116,7 +116,7 @@ func ApplyFilterAndGetFilteredList(ctx context.Context, acrClient api.AcrCLIClie
 		if filterRepo.Enabled != nil && !*filterRepo.Enabled {
 			continue
 		}
-		if filterRepo.Repository == "" || filterRepo.Tags == nil || len(filterRepo.Tags) == 0 || filterRepo.Tags[0] == "" {
+		if filterRepo.Repository == "" || filterRepo.Tags == nil || len(filterRepo.Tags) == 0 {
 			continue
 		}
 

--- a/internal/cssc/cssc.go
+++ b/internal/cssc/cssc.go
@@ -177,12 +177,17 @@ func PrintFilteredResult(filteredResult []FilteredRepository, showPatchTags bool
 
 // Appends the element to the slice if it does not already exist in the slice
 func AppendElement(slice []FilteredRepository, element FilteredRepository) []FilteredRepository {
+	isFirstElement := len(slice) == 0
+	alreadyInSlice := false
 	for i, existing := range slice {
 		if existing.Repository == element.Repository && existing.Tag == element.Tag {
-			slice = append(slice[:i], slice[i+1:]...)
+			slice[i].PatchTag = element.PatchTag
+			alreadyInSlice = true
 			break
 		}
 	}
-	// Append the new element to the slice
-	return append(slice, element)
+	if isFirstElement || !alreadyInSlice {
+		slice = append(slice, element)
+	}
+	return slice
 }

--- a/internal/cssc/cssc.go
+++ b/internal/cssc/cssc.go
@@ -11,9 +11,9 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/Azure/acr-cli/internal/api"
 	"github.com/Azure/acr-cli/internal/tag"
 
-	"github.com/Azure/acr-cli/cmd/api"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 

--- a/internal/cssc/cssc_test.go
+++ b/internal/cssc/cssc_test.go
@@ -1,0 +1,280 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cssc
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/Azure/acr-cli/cmd/mocks"
+	"github.com/Azure/acr-cli/internal/common"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestApplyFilterAndGetFilteredList(t *testing.T) {
+	mockAcrClient := &mocks.AcrCLIClientInterface{}
+	// 1. If filter contains only one repository and it is not specified, nothing will match the filter and an empty list should be returned
+	t.Run("RepositoryNotSpecifiedTest", func(t *testing.T) {
+		filter := Filter{
+			Version: "v1",
+			Repositories: []Repository{
+				{
+					Repository: "",
+					Tags:       []string{common.TagName1, common.TagName2},
+					Enabled:    boolPtr(true),
+				},
+			},
+		}
+		filteredRepositories, err := ApplyFilterAndGetFilteredList(context.Background(), mockAcrClient, filter)
+		assert.NoError(t, err)
+		assert.Nil(t, filteredRepositories)
+		assert.Len(t, filteredRepositories, 0)
+	})
+	//2.  If Tags are not specified for any repository in the filter, nothing will match the filter and an empty list should be returned
+	t.Run("TagsNotSpecifiedTest", func(t *testing.T) {
+		filter := Filter{
+			Version: "v1",
+			Repositories: []Repository{
+				{
+					Repository: common.RepoName1,
+					Tags:       nil,
+					Enabled:    boolPtr(true),
+				},
+				{
+					Repository: common.RepoName2,
+					Tags:       []string{""},
+					Enabled:    boolPtr(true),
+				},
+			},
+		}
+		filteredRepositories, err := ApplyFilterAndGetFilteredList(context.Background(), mockAcrClient, filter)
+		assert.NoError(t, err)
+		assert.Nil(t, filteredRepositories)
+		assert.Len(t, filteredRepositories, 0)
+	})
+	//3. Error should be returned when GetAcrTags fails for a repository
+	t.Run("GetAcrTagsFailsTest", func(t *testing.T) {
+		filter := Filter{
+			Version: "v1",
+			Repositories: []Repository{
+				{
+					Repository: common.RepoName1,
+					Tags:       []string{common.TagName1, common.TagName2},
+					Enabled:    boolPtr(true),
+				},
+			},
+		}
+		mockAcrClient.On("GetAcrTags", common.TestCtx, common.RepoName1, "", "").Return(nil, errors.New("failed getting the tags")).Once()
+		filteredRepositories, err := ApplyFilterAndGetFilteredList(context.Background(), mockAcrClient, filter)
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "failed getting the tags")
+		assert.Nil(t, filteredRepositories)
+	})
+	//4. If filter has a tag that doesn't exist in the repository, ignore it and return whatever exists that matches the filter
+	t.Run("TagSpecifiedInFilterDoesNotExistTest", func(t *testing.T) {
+		filter := Filter{
+			Version: "v1",
+			Repositories: []Repository{
+				{
+					Repository: common.RepoName1,
+					Tags:       []string{common.TagName, common.TagName1},
+					Enabled:    boolPtr(true),
+				},
+			},
+		}
+		mockAcrClient.On("GetAcrTags", common.TestCtx, common.RepoName1, "", "").Return(common.OneTagResult, nil).Once()
+		mockAcrClient.On("GetAcrTags", common.TestCtx, common.RepoName1, "", common.TagName).Return(common.EmptyListTagsResult, nil).Once()
+		filteredRepositories, err := ApplyFilterAndGetFilteredList(context.Background(), mockAcrClient, filter)
+		assert.NoError(t, err)
+		assert.Len(t, filteredRepositories, 1)
+		assert.Equal(t, common.RepoName1, filteredRepositories[0].Repository)
+		assert.Equal(t, common.TagName, filteredRepositories[0].Tag)
+	})
+	// 5. Success scenario with all the combination of filters
+	t.Run("AllFilterCombinationTest", func(t *testing.T) {
+		filter := Filter{
+			Version: "v1",
+			Repositories: []Repository{
+				{
+					Repository: common.RepoName1,
+					Tags:       []string{common.TagName1, common.TagName2}, // tags specified
+					Enabled:    boolPtr(true),
+				},
+				{
+					Repository: common.RepoName2,
+					Tags:       []string{"*"}, // * all tags
+					Enabled:    boolPtr(true),
+				},
+				{
+					Repository: common.RepoName3,
+					Tags:       []string{common.TagName1, common.TagName2},
+					Enabled:    nil, // nil means enabled
+				},
+				{
+					Repository: common.RepoName4,
+					Tags:       []string{common.TagName1, common.TagName2},
+					Enabled:    boolPtr(false), // disabled repository for all tags
+				},
+			},
+		}
+		mockAcrClient.On("GetAcrTags", common.TestCtx, common.RepoName1, "", "").Return(common.FourTagResultWithPatchTags, nil).Once()
+		mockAcrClient.On("GetAcrTags", common.TestCtx, common.RepoName1, "", common.TagNamePatch2).Return(common.EmptyListTagsResult, nil).Once()
+		mockAcrClient.On("GetAcrTags", common.TestCtx, common.RepoName2, "", "").Return(common.FourTagResultWithPatchTags, nil).Once()
+		mockAcrClient.On("GetAcrTags", common.TestCtx, common.RepoName2, "", common.TagNamePatch2).Return(common.EmptyListTagsResult, nil).Once()
+		mockAcrClient.On("GetAcrTags", common.TestCtx, common.RepoName3, "", "").Return(common.FourTagResultWithPatchTags, nil).Once()
+		mockAcrClient.On("GetAcrTags", common.TestCtx, common.RepoName3, "", common.TagNamePatch2).Return(common.EmptyListTagsResult, nil).Once()
+		mockAcrClient.On("GetAcrTags", common.TestCtx, common.RepoName4, "", "").Return(common.FourTagResultWithPatchTags, nil).Once()
+		mockAcrClient.On("GetAcrTags", common.TestCtx, common.RepoName4, "", common.TagNamePatch2).Return(common.EmptyListTagsResult, nil).Once()
+		filteredRepositories, err := ApplyFilterAndGetFilteredList(context.Background(), mockAcrClient, filter)
+		assert.NoError(t, err)
+		assert.Len(t, filteredRepositories, 6)
+		assert.Equal(t, common.RepoName1, filteredRepositories[0].Repository)
+		assert.Equal(t, common.TagName1, filteredRepositories[0].Tag)
+		assert.Equal(t, common.TagNamePatch1, filteredRepositories[0].PatchTag)
+		assert.Equal(t, common.RepoName1, filteredRepositories[1].Repository)
+		assert.Equal(t, common.TagName2, filteredRepositories[1].Tag)
+		assert.Equal(t, common.TagNamePatch2, filteredRepositories[1].PatchTag)
+		assert.Equal(t, common.RepoName2, filteredRepositories[2].Repository)
+		assert.Equal(t, common.TagName1, filteredRepositories[2].Tag)
+		assert.Equal(t, common.TagNamePatch1, filteredRepositories[2].PatchTag)
+		assert.Equal(t, common.RepoName2, filteredRepositories[3].Repository)
+		assert.Equal(t, common.TagName2, filteredRepositories[3].Tag)
+		assert.Equal(t, common.TagNamePatch2, filteredRepositories[3].PatchTag)
+		assert.Equal(t, common.RepoName3, filteredRepositories[4].Repository)
+		assert.Equal(t, common.TagName1, filteredRepositories[4].Tag)
+		assert.Equal(t, common.TagNamePatch1, filteredRepositories[4].PatchTag)
+		assert.Equal(t, common.RepoName3, filteredRepositories[5].Repository)
+		assert.Equal(t, common.TagName2, filteredRepositories[5].Tag)
+		assert.Equal(t, common.TagNamePatch2, filteredRepositories[5].PatchTag)
+	})
+}
+
+func TestGetFilterFromFilterPolicy(t *testing.T) {
+	username := "username"
+	password := "password"
+	//1. Error should be returned when filter policy is not in the correct format
+	t.Run("FilterPolicyNotCorrectFormatTest", func(t *testing.T) {
+		filterPolicy := "notcorrectformat"
+		filter, err := GetFilterFromFilterPolicy(context.Background(), filterPolicy, common.TestLoginURL, username, password)
+		assert.NotEqual(nil, err, "Error should not be nil")
+		assert.Equal(t, "filter-policy should be in the format repo:tag", err.Error())
+		assert.Equal(t, Filter{}, filter)
+	})
+	//2. Error should be returned when fetching repository manifest fails
+	t.Run("FetchBytesFailsTest", func(t *testing.T) {
+		filterPolicy := "repo1:tag1"
+		filter, err := GetFilterFromFilterPolicy(context.Background(), filterPolicy, common.TestLoginURL, username, password)
+		assert.NotEqual(nil, err, "Error should not be nil")
+		assert.ErrorContains(t, err, "error fetching manifest content when reading the filter policy")
+		assert.Equal(t, Filter{}, filter)
+	})
+}
+
+func TestGetFilterFromFilePath(t *testing.T) {
+	//1. Error should be returned when filter file does not exist
+	t.Run("FileDoesNotExistTest", func(t *testing.T) {
+		filter, err := GetFilterFromFilePath("idontexist")
+		assert.NotEqual(nil, err, "Error should not be nil")
+		assert.ErrorContains(t, err, "error reading the filter json file from file path")
+		assert.Equal(t, Filter{}, filter)
+	})
+	//2. Error should be returned when filter file is not in the correct format
+	t.Run("FileNotCorrectFormatTest", func(t *testing.T) {
+		var filterFile = []byte(`i am not a json file`)
+		err := os.WriteFile("filter-wrongformat.json", filterFile, 0600)
+		assert.Nil(t, err, "Error should be nil")
+		filter, err := GetFilterFromFilePath("filter-wrongformat.json")
+		assert.NotEqual(nil, err, "Error should not be nil")
+		assert.ErrorContains(t, err, "error unmarshalling json content when reading the filter file from file path")
+		assert.Equal(t, Filter{}, filter)
+		err = os.Remove("filter-wrongformat.json")
+		assert.Nil(t, err, "Error should be nil")
+	})
+	//3. Success scenario with correct filter file
+	t.Run("SuccessTest", func(t *testing.T) {
+		var filterFile = []byte(`{
+			"version": "v1",
+			"repositories": [
+				{
+					"repository": "repo1",
+					"tags": ["v1", "v2"],
+					"enabled": true
+				},
+				{
+					"repository": "repo2",
+					"tags": ["v1"],
+					"enabled": true
+				}
+			]
+		}`)
+		err := os.WriteFile("filter.json", filterFile, 0600)
+		assert.Nil(t, err, "Error should be nil")
+		filter, err := GetFilterFromFilePath("filter.json")
+		assert.Nil(t, err, "Error should be nil")
+		assert.Equal(t, "v1", filter.Version)
+		assert.Len(t, filter.Repositories, 2)
+		assert.Equal(t, common.RepoName1, filter.Repositories[0].Repository)
+		assert.Equal(t, common.TagName1, filter.Repositories[0].Tags[0])
+		assert.Equal(t, common.TagName2, filter.Repositories[0].Tags[1])
+		assert.Equal(t, true, *filter.Repositories[0].Enabled)
+		assert.Equal(t, common.RepoName2, filter.Repositories[1].Repository)
+		assert.Equal(t, common.TagName1, filter.Repositories[1].Tags[0])
+		assert.Equal(t, true, *filter.Repositories[1].Enabled)
+		err = os.Remove("filter.json")
+		assert.Nil(t, err, "Error should be nil")
+	})
+}
+
+func TestAppendElement(t *testing.T) {
+	// 1. Should append the element to the slice when the slice does not contain the element
+	t.Run("AppendElementTest", func(t *testing.T) {
+		slice := []FilteredRepository{
+			{
+				Repository: common.RepoName1,
+				Tag:        common.TagName1,
+				PatchTag:   common.TagNamePatch1,
+			},
+		}
+		element := FilteredRepository{
+			Repository: common.RepoName2,
+			Tag:        common.TagName2,
+			PatchTag:   common.TagNamePatch2,
+		}
+		newSlice := AppendElement(slice, element)
+		assert.Len(t, newSlice, 2)
+		assert.Equal(t, common.RepoName1, newSlice[0].Repository)
+		assert.Equal(t, common.TagName1, newSlice[0].Tag)
+		assert.Equal(t, common.TagNamePatch1, newSlice[0].PatchTag)
+		assert.Equal(t, common.RepoName2, newSlice[1].Repository)
+		assert.Equal(t, common.TagName2, newSlice[1].Tag)
+		assert.Equal(t, common.TagNamePatch2, newSlice[1].PatchTag)
+	})
+	// 2. Should not append the element to the slice when the slice already contains the element
+	t.Run("AppendElementAlreadyExistsTest", func(t *testing.T) {
+		slice := []FilteredRepository{
+			{
+				Repository: common.RepoName1,
+				Tag:        common.TagName1,
+				PatchTag:   common.TagNamePatch1,
+			},
+		}
+		element := FilteredRepository{
+			Repository: common.RepoName1,
+			Tag:        common.TagName1,
+			PatchTag:   common.TagNamePatch1,
+		}
+		newSlice := AppendElement(slice, element)
+		assert.Len(t, newSlice, 1)
+		assert.Equal(t, common.RepoName1, newSlice[0].Repository)
+		assert.Equal(t, common.TagName1, newSlice[0].Tag)
+		assert.Equal(t, common.TagNamePatch1, newSlice[0].PatchTag)
+	})
+}
+
+// Helper function to create a pointer to a bool
+func boolPtr(v bool) *bool {
+	return &v
+}

--- a/internal/cssc/cssc_test.go
+++ b/internal/cssc/cssc_test.go
@@ -44,11 +44,6 @@ func TestApplyFilterAndGetFilteredList(t *testing.T) {
 					Tags:       nil,
 					Enabled:    boolPtr(true),
 				},
-				{
-					Repository: common.RepoName2,
-					Tags:       []string{""},
-					Enabled:    boolPtr(true),
-				},
 			},
 		}
 		filteredRepositories, err := ApplyFilterAndGetFilteredList(context.Background(), mockAcrClient, filter)

--- a/internal/tag/tag.go
+++ b/internal/tag/tag.go
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package tag
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/acr-cli/acr"
+	"github.com/Azure/acr-cli/cmd/api"
+	"github.com/pkg/errors"
+)
+
+// ListTags will do the http requests and return the digest of all the tags in the selected repository.
+func ListTags(ctx context.Context, acrClient api.AcrCLIClientInterface, repoName string) ([]acr.TagAttributesBase, error) {
+
+	lastTag := ""
+	resultTags, err := acrClient.GetAcrTags(ctx, repoName, "", lastTag)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list tags")
+	}
+
+	var tagList []acr.TagAttributesBase
+	tagList = append(tagList, *resultTags.TagsAttributes...)
+
+	// A for loop is used because the GetAcrTags method returns by default only 100 tags and their attributes.
+	for resultTags != nil && resultTags.TagsAttributes != nil {
+		tags := *resultTags.TagsAttributes
+
+		// Since the GetAcrTags supports pagination when supplied with the last digest that was returned the last tag name
+		// digest is saved, the tag array contains at least one element because if it was empty the API would return
+		// a nil pointer instead of a pointer to a length 0 array.
+		lastTag = *tags[len(tags)-1].Name
+		resultTags, err = acrClient.GetAcrTags(ctx, repoName, "", lastTag)
+		if err != nil {
+			return nil, err
+		}
+		if resultTags != nil && resultTags.TagsAttributes != nil {
+			tagList = append(tagList, *resultTags.TagsAttributes...)
+		}
+	}
+
+	return tagList, nil
+}
+
+// DeleteTags receives an array of tags digest and deletes them using the supplied acrClient.
+func DeleteTags(ctx context.Context, acrClient api.AcrCLIClientInterface, loginURL string, repoName string, args []string) error {
+	for i := 0; i < len(args); i++ {
+		_, err := acrClient.DeleteAcrTag(ctx, repoName, args[i])
+		if err != nil {
+			// If there is an error (this includes not found and not allowed operations) the deletion of the tags is stopped and an error is returned.
+			return errors.Wrap(err, "failed to delete tags")
+		}
+		fmt.Printf("%s/%s:%s\n", loginURL, repoName, args[i])
+	}
+	return nil
+}

--- a/internal/tag/tag.go
+++ b/internal/tag/tag.go
@@ -12,13 +12,21 @@ import (
 	"github.com/pkg/errors"
 )
 
+type ListTagsError struct {
+	msg string
+}
+
+func (e *ListTagsError) Error() string {
+	return e.msg
+}
+
 // ListTags will do the http requests and return the digest of all the tags in the selected repository.
 func ListTags(ctx context.Context, acrClient api.AcrCLIClientInterface, repoName string) ([]acr.TagAttributesBase, error) {
 
 	lastTag := ""
 	resultTags, err := acrClient.GetAcrTags(ctx, repoName, "", lastTag)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to list tags")
+		return nil, errors.Wrap(&ListTagsError{msg: "failed to list tags"}, err.Error())
 	}
 
 	var tagList []acr.TagAttributesBase
@@ -45,14 +53,14 @@ func ListTags(ctx context.Context, acrClient api.AcrCLIClientInterface, repoName
 }
 
 // DeleteTags receives an array of tags digest and deletes them using the supplied acrClient.
-func DeleteTags(ctx context.Context, acrClient api.AcrCLIClientInterface, loginURL string, repoName string, args []string) error {
-	for i := 0; i < len(args); i++ {
-		_, err := acrClient.DeleteAcrTag(ctx, repoName, args[i])
+func DeleteTags(ctx context.Context, acrClient api.AcrCLIClientInterface, loginURL string, repoName string, tags []string) error {
+	for i := 0; i < len(tags); i++ {
+		_, err := acrClient.DeleteAcrTag(ctx, repoName, tags[i])
 		if err != nil {
 			// If there is an error (this includes not found and not allowed operations) the deletion of the tags is stopped and an error is returned.
 			return errors.Wrap(err, "failed to delete tags")
 		}
-		fmt.Printf("%s/%s:%s\n", loginURL, repoName, args[i])
+		fmt.Printf("%s/%s:%s\n", loginURL, repoName, tags[i])
 	}
 	return nil
 }

--- a/internal/tag/tag.go
+++ b/internal/tag/tag.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 
 	"github.com/Azure/acr-cli/acr"
-	"github.com/Azure/acr-cli/cmd/api"
+	"github.com/Azure/acr-cli/internal/api"
 	"github.com/pkg/errors"
 )
 

--- a/internal/tag/tag_test.go
+++ b/internal/tag/tag_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package tag
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Azure/acr-cli/cmd/mocks"
+	"github.com/Azure/acr-cli/internal/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListTags(t *testing.T) {
+	// First test, repository not found should return an error.
+	t.Run("RepositoryNotFoundTest", func(t *testing.T) {
+		assert := assert.New(t)
+		mockClient := &mocks.AcrCLIClientInterface{}
+		mockClient.On("GetAcrTags", common.TestCtx, common.TestRepo, "", "").Return(common.NotFoundTagResponse, errors.New("testRepo not found")).Once()
+		tagList, err := ListTags(common.TestCtx, mockClient, common.TestRepo)
+		assert.NotEqual(nil, err, "Error should not be nil")
+		assert.Equal(0, len(tagList), "Tag list should be empty")
+		mockClient.AssertExpectations(t)
+	})
+	// Second test, if an error is returned on any GetAcrTags call an error should be returned.
+	t.Run("ErrorOnSecondPageTest", func(t *testing.T) {
+		assert := assert.New(t)
+		mockClient := &mocks.AcrCLIClientInterface{}
+		mockClient.On("GetAcrTags", common.TestCtx, common.TestRepo, "", "").Return(common.OneTagResult, nil).Once()
+		mockClient.On("GetAcrTags", common.TestCtx, common.TestRepo, "", "latest").Return(nil, errors.New("unauthorized")).Once()
+		tagList, err := ListTags(common.TestCtx, mockClient, common.TestRepo)
+		assert.Equal(0, len(tagList), "Tag list should be empty")
+		assert.NotEqual(nil, err, "Error should not be nil")
+		mockClient.AssertExpectations(t)
+	})
+	// Third test, no errors
+	t.Run("ListFiveTagsTest", func(t *testing.T) {
+		assert := assert.New(t)
+		mockClient := &mocks.AcrCLIClientInterface{}
+		mockClient.On("GetAcrTags", common.TestCtx, common.TestRepo, "", "").Return(common.OneTagResult, nil).Once()
+		mockClient.On("GetAcrTags", common.TestCtx, common.TestRepo, "", "latest").Return(common.FourTagsResult, nil).Once()
+		mockClient.On("GetAcrTags", common.TestCtx, common.TestRepo, "", "v4").Return(common.EmptyListTagsResult, nil).Once()
+		tagList, err := ListTags(common.TestCtx, mockClient, common.TestRepo)
+		assert.Equal(nil, err, "Error should be nil")
+		assert.Equal(5, len(tagList), "Tag list should have 5 tags")
+		mockClient.AssertExpectations(t)
+	})
+}
+
+func TestDeleteTags(t *testing.T) {
+	args := []string{common.TagName, common.TagName1, common.TagName2, common.TagName3, common.TagName4}
+	// First test, tag not found should return an error.
+	t.Run("TagNotFoundTest", func(t *testing.T) {
+		assert := assert.New(t)
+		mockClient := &mocks.AcrCLIClientInterface{}
+		mockClient.On("DeleteAcrTag", common.TestCtx, common.TestRepo, "latest").Return(&common.NotFoundResponse, errors.New("not found")).Once()
+		err := DeleteTags(common.TestCtx, mockClient, common.TestLoginURL, common.TestRepo, args)
+		assert.NotEqual(nil, err, "Error should not be nil")
+		mockClient.AssertExpectations(t)
+	})
+	// Second test, five tags deleted, regular behavior
+	t.Run("DeleteFiveTagsTest", func(t *testing.T) {
+		assert := assert.New(t)
+		mockClient := &mocks.AcrCLIClientInterface{}
+		mockClient.On("DeleteAcrTag", common.TestCtx, common.TestRepo, "latest").Return(&common.DeletedResponse, nil).Once()
+		mockClient.On("DeleteAcrTag", common.TestCtx, common.TestRepo, "v1").Return(&common.DeletedResponse, nil).Once()
+		mockClient.On("DeleteAcrTag", common.TestCtx, common.TestRepo, "v2").Return(&common.DeletedResponse, nil).Once()
+		mockClient.On("DeleteAcrTag", common.TestCtx, common.TestRepo, "v3").Return(&common.DeletedResponse, nil).Once()
+		mockClient.On("DeleteAcrTag", common.TestCtx, common.TestRepo, "v4").Return(&common.DeletedResponse, nil).Once()
+		err := DeleteTags(common.TestCtx, mockClient, common.TestLoginURL, common.TestRepo, args)
+		assert.Equal(nil, err, "Error should be nil")
+		mockClient.AssertExpectations(t)
+	})
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -109,14 +109,22 @@ gopkg.in/yaml.v3
 ## explicit; go 1.13
 # oras.land/oras-go/v2 v2.5.0
 ## explicit; go 1.21
+oras.land/oras-go/v2
 oras.land/oras-go/v2/content
 oras.land/oras-go/v2/errdef
 oras.land/oras-go/v2/internal/cas
+oras.land/oras-go/v2/internal/container/set
+oras.land/oras-go/v2/internal/copyutil
 oras.land/oras-go/v2/internal/descriptor
 oras.land/oras-go/v2/internal/docker
 oras.land/oras-go/v2/internal/httputil
+oras.land/oras-go/v2/internal/interfaces
 oras.land/oras-go/v2/internal/ioutil
+oras.land/oras-go/v2/internal/manifestutil
+oras.land/oras-go/v2/internal/platform
+oras.land/oras-go/v2/internal/registryutil
 oras.land/oras-go/v2/internal/spec
+oras.land/oras-go/v2/internal/status
 oras.land/oras-go/v2/internal/syncutil
 oras.land/oras-go/v2/registry
 oras.land/oras-go/v2/registry/remote

--- a/vendor/oras.land/oras-go/v2/.gitignore
+++ b/vendor/oras.land/oras-go/v2/.gitignore
@@ -1,0 +1,41 @@
+# Copyright The ORAS Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# VS Code
+.vscode
+debug
+
+# Jetbrains
+.idea
+
+# Custom
+coverage.txt
+bin/
+dist/
+*.tar.gz
+vendor/
+_dist/
+.cover

--- a/vendor/oras.land/oras-go/v2/CODEOWNERS
+++ b/vendor/oras.land/oras-go/v2/CODEOWNERS
@@ -1,0 +1,2 @@
+# Derived from OWNERS.md
+* @sajayantony @shizhMSFT @stevelasker @Wwwsylvia

--- a/vendor/oras.land/oras-go/v2/CODE_OF_CONDUCT.md
+++ b/vendor/oras.land/oras-go/v2/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+OCI Registry As Storage (ORAS) follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).

--- a/vendor/oras.land/oras-go/v2/MIGRATION_GUIDE.md
+++ b/vendor/oras.land/oras-go/v2/MIGRATION_GUIDE.md
@@ -1,0 +1,45 @@
+# Migration Guide
+
+In version `v2`, ORAS Go library has been completely refreshed with:
+
+- More unified interfaces
+- Notably fewer dependencies
+- Higher test coverage
+- Better documentation
+
+**Besides, ORAS Go `v2` is now a registry client.**
+
+## Major Changes in `v2`
+
+- Moves `content.FileStore` to [file.Store](https://pkg.go.dev/oras.land/oras-go/v2/content/file#Store)
+- Moves `content.OCIStore` to [oci.Store](https://pkg.go.dev/oras.land/oras-go/v2/content/oci#Store)
+- Moves `content.MemoryStore` to [memory.Store](https://pkg.go.dev/oras.land/oras-go/v2/content/memory#Store)
+- Provides [SDK](https://pkg.go.dev/oras.land/oras-go/v2/registry/remote) to interact with OCI-compliant and Docker-compliant registries
+- Supports [Copy](https://pkg.go.dev/oras.land/oras-go/v2#Copy) with more flexible options
+- Supports [Extended Copy](https://pkg.go.dev/oras.land/oras-go/v2#ExtendedCopy) with options *(experimental)*
+- No longer supports `docker.Login` and `docker.Logout` (removes the dependency on `docker`); instead, provides authentication through [auth.Client](https://pkg.go.dev/oras.land/oras-go/v2/registry/remote/auth#Client)
+
+Documentation and examples are available at [pkg.go.dev](https://pkg.go.dev/oras.land/oras-go/v2).
+
+## Migrating from `v1` to `v2`
+
+1. Get the `v2` package
+
+    ```sh
+    go get oras.land/oras-go/v2
+    ```
+
+2. Import and use the `v2` package
+
+    ```go
+    import "oras.land/oras-go/v2"
+    ```
+
+3. Run
+
+   ```sh
+   go mod tidy
+    ```
+
+Since breaking changes are introduced in `v2`, code refactoring is required for migrating from `v1` to `v2`.  
+The migration can be done in an iterative fashion, as `v1` and `v2` can be imported and used at the same time.

--- a/vendor/oras.land/oras-go/v2/Makefile
+++ b/vendor/oras.land/oras-go/v2/Makefile
@@ -1,0 +1,38 @@
+# Copyright The ORAS Authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+.PHONY: test
+test: vendor check-encoding
+	go test -race -v -coverprofile=coverage.txt -covermode=atomic ./...
+
+.PHONY: covhtml
+covhtml:
+	open .cover/coverage.html
+
+.PHONY: clean
+clean:
+	git status --ignored --short | grep '^!! ' | sed 's/!! //' | xargs rm -rf
+
+.PHONY: check-encoding
+check-encoding:
+	! find . -not -path "./vendor/*" -name "*.go" -type f -exec file "{}" ";" | grep CRLF
+	! find scripts -name "*.sh" -type f -exec file "{}" ";" | grep CRLF
+
+.PHONY: fix-encoding
+fix-encoding:
+	find . -not -path "./vendor/*" -name "*.go" -type f -exec sed -i -e "s/\r//g" {} +
+	find scripts -name "*.sh" -type f -exec sed -i -e "s/\r//g" {} +
+
+.PHONY: vendor
+vendor:
+	go mod vendor

--- a/vendor/oras.land/oras-go/v2/OWNERS.md
+++ b/vendor/oras.land/oras-go/v2/OWNERS.md
@@ -1,0 +1,11 @@
+# Owners
+
+Owners:
+  - Sajay Antony (@sajayantony)
+  - Shiwei Zhang (@shizhMSFT)
+  - Steve Lasker (@stevelasker)
+  - Sylvia Lei (@Wwwsylvia)
+
+Emeritus:
+  - Avi Deitcher (@deitch)
+  - Josh Dolitsky (@jdolitsky)

--- a/vendor/oras.land/oras-go/v2/README.md
+++ b/vendor/oras.land/oras-go/v2/README.md
@@ -1,0 +1,58 @@
+# ORAS Go library
+
+<p align="left">
+<a href="https://oras.land/"><img src="https://oras.land/img/oras.svg" alt="banner" width="100px"></a>
+</p>
+
+## Project status
+
+### Versioning
+
+The ORAS Go library follows [Semantic Versioning](https://semver.org/), where breaking changes are reserved for MAJOR releases, and MINOR and PATCH releases must be 100% backwards compatible.
+
+### v2: stable
+
+[![Build Status](https://github.com/oras-project/oras-go/actions/workflows/build.yml/badge.svg?event=push&branch=main)](https://github.com/oras-project/oras-go/actions/workflows/build.yml?query=workflow%3Abuild+event%3Apush+branch%3Amain)
+[![codecov](https://codecov.io/gh/oras-project/oras-go/branch/main/graph/badge.svg)](https://codecov.io/gh/oras-project/oras-go)
+[![Go Report Card](https://goreportcard.com/badge/oras.land/oras-go/v2)](https://goreportcard.com/report/oras.land/oras-go/v2)
+[![Go Reference](https://pkg.go.dev/badge/oras.land/oras-go/v2.svg)](https://pkg.go.dev/oras.land/oras-go/v2)
+
+The version `2` is actively developed in the [`main`](https://github.com/oras-project/oras-go/tree/main) branch with all new features.
+
+> [!Note]
+> The `main` branch follows [Go's Security Policy](https://github.com/golang/go/security/policy) and supports the two latest versions of Go (currently `1.21` and `1.22`).
+
+Examples for common use cases can be found below:
+
+- [Copy examples](https://pkg.go.dev/oras.land/oras-go/v2#pkg-examples)
+- [Registry interaction examples](https://pkg.go.dev/oras.land/oras-go/v2/registry#pkg-examples)
+- [Repository interaction examples](https://pkg.go.dev/oras.land/oras-go/v2/registry/remote#pkg-examples)
+- [Authentication examples](https://pkg.go.dev/oras.land/oras-go/v2/registry/remote/auth#pkg-examples)
+
+If you are seeking latest changes, you should use the [`main`](https://github.com/oras-project/oras-go/tree/main) branch (or a specific commit hash) over a tagged version when including the ORAS Go library in your project's `go.mod`.
+The Go Reference for the `main` branch is available [here](https://pkg.go.dev/oras.land/oras-go/v2@main).
+
+To migrate from `v1` to `v2`, see [MIGRATION_GUIDE.md](./MIGRATION_GUIDE.md).
+
+### v1: stable
+
+[![Build Status](https://github.com/oras-project/oras-go/actions/workflows/build.yml/badge.svg?event=push&branch=v1)](https://github.com/oras-project/oras-go/actions/workflows/build.yml?query=workflow%3Abuild+event%3Apush+branch%3Av1)
+[![Go Report Card](https://goreportcard.com/badge/oras.land/oras-go)](https://goreportcard.com/report/oras.land/oras-go)
+[![Go Reference](https://pkg.go.dev/badge/oras.land/oras-go.svg)](https://pkg.go.dev/oras.land/oras-go)
+
+As there are various stable projects depending on the ORAS Go library `v1`, the
+[`v1`](https://github.com/oras-project/oras-go/tree/v1) branch
+is maintained for API stability, dependency updates, and security patches.
+All `v1.*` releases are based upon this branch.
+
+Since `v1` is in a maintenance state, you are highly encouraged
+to use releases with major version `2` for new features.
+
+## Docs
+
+- [oras.land/client_libraries/go](https://oras.land/docs/Client_Libraries/go): Documentation for the ORAS Go library
+- [Reviewing guide](https://github.com/oras-project/community/blob/main/REVIEWING.md): All reviewers must read the reviewing guide and agree to follow the project review guidelines.
+
+## Code of Conduct
+
+This project has adopted the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md). See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for further details.

--- a/vendor/oras.land/oras-go/v2/SECURITY.md
+++ b/vendor/oras.land/oras-go/v2/SECURITY.md
@@ -1,0 +1,3 @@
+# Security Policy
+
+Please follow the [security policy](https://oras.land/docs/community/reporting_security_concerns) to report a security vulnerability or concern.

--- a/vendor/oras.land/oras-go/v2/content.go
+++ b/vendor/oras.land/oras-go/v2/content.go
@@ -1,0 +1,411 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oras
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/content"
+	"oras.land/oras-go/v2/errdef"
+	"oras.land/oras-go/v2/internal/cas"
+	"oras.land/oras-go/v2/internal/docker"
+	"oras.land/oras-go/v2/internal/interfaces"
+	"oras.land/oras-go/v2/internal/platform"
+	"oras.land/oras-go/v2/internal/syncutil"
+	"oras.land/oras-go/v2/registry"
+	"oras.land/oras-go/v2/registry/remote/auth"
+)
+
+const (
+	// defaultTagConcurrency is the default concurrency of tagging.
+	defaultTagConcurrency int = 5 // This value is consistent with dockerd
+
+	// defaultTagNMaxMetadataBytes is the default value of
+	// TagNOptions.MaxMetadataBytes.
+	defaultTagNMaxMetadataBytes int64 = 4 * 1024 * 1024 // 4 MiB
+
+	// defaultResolveMaxMetadataBytes is the default value of
+	// ResolveOptions.MaxMetadataBytes.
+	defaultResolveMaxMetadataBytes int64 = 4 * 1024 * 1024 // 4 MiB
+
+	// defaultMaxBytes is the default value of FetchBytesOptions.MaxBytes.
+	defaultMaxBytes int64 = 4 * 1024 * 1024 // 4 MiB
+)
+
+// DefaultTagNOptions provides the default TagNOptions.
+var DefaultTagNOptions TagNOptions
+
+// TagNOptions contains parameters for [oras.TagN].
+type TagNOptions struct {
+	// Concurrency limits the maximum number of concurrent tag tasks.
+	// If less than or equal to 0, a default (currently 5) is used.
+	Concurrency int
+
+	// MaxMetadataBytes limits the maximum size of metadata that can be cached
+	// in the memory.
+	// If less than or equal to 0, a default (currently 4 MiB) is used.
+	MaxMetadataBytes int64
+}
+
+// TagN tags the descriptor identified by srcReference with dstReferences.
+func TagN(ctx context.Context, target Target, srcReference string, dstReferences []string, opts TagNOptions) (ocispec.Descriptor, error) {
+	switch len(dstReferences) {
+	case 0:
+		return ocispec.Descriptor{}, fmt.Errorf("dstReferences cannot be empty: %w", errdef.ErrMissingReference)
+	case 1:
+		return Tag(ctx, target, srcReference, dstReferences[0])
+	}
+
+	if opts.Concurrency <= 0 {
+		opts.Concurrency = defaultTagConcurrency
+	}
+	if opts.MaxMetadataBytes <= 0 {
+		opts.MaxMetadataBytes = defaultTagNMaxMetadataBytes
+	}
+
+	_, isRefFetcher := target.(registry.ReferenceFetcher)
+	_, isRefPusher := target.(registry.ReferencePusher)
+	if isRefFetcher && isRefPusher {
+		if repo, ok := target.(interfaces.ReferenceParser); ok {
+			// add scope hints to minimize the number of auth requests
+			ref, err := repo.ParseReference(srcReference)
+			if err != nil {
+				return ocispec.Descriptor{}, err
+			}
+			ctx = auth.AppendRepositoryScope(ctx, ref, auth.ActionPull, auth.ActionPush)
+		}
+
+		desc, contentBytes, err := FetchBytes(ctx, target, srcReference, FetchBytesOptions{
+			MaxBytes: opts.MaxMetadataBytes,
+		})
+		if err != nil {
+			if errors.Is(err, errdef.ErrSizeExceedsLimit) {
+				err = fmt.Errorf(
+					"content size %v exceeds MaxMetadataBytes %v: %w",
+					desc.Size,
+					opts.MaxMetadataBytes,
+					errdef.ErrSizeExceedsLimit)
+			}
+			return ocispec.Descriptor{}, err
+		}
+
+		if err := tagBytesN(ctx, target, desc, contentBytes, dstReferences, TagBytesNOptions{
+			Concurrency: opts.Concurrency,
+		}); err != nil {
+			return ocispec.Descriptor{}, err
+		}
+		return desc, nil
+	}
+
+	desc, err := target.Resolve(ctx, srcReference)
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+	eg, egCtx := syncutil.LimitGroup(ctx, opts.Concurrency)
+	for _, dstRef := range dstReferences {
+		eg.Go(func(dst string) func() error {
+			return func() error {
+				if err := target.Tag(egCtx, desc, dst); err != nil {
+					return fmt.Errorf("failed to tag %s as %s: %w", srcReference, dst, err)
+				}
+				return nil
+			}
+		}(dstRef))
+	}
+
+	if err := eg.Wait(); err != nil {
+		return ocispec.Descriptor{}, err
+	}
+	return desc, nil
+}
+
+// Tag tags the descriptor identified by src with dst.
+func Tag(ctx context.Context, target Target, src, dst string) (ocispec.Descriptor, error) {
+	refFetcher, okFetch := target.(registry.ReferenceFetcher)
+	refPusher, okPush := target.(registry.ReferencePusher)
+	if okFetch && okPush {
+		if repo, ok := target.(interfaces.ReferenceParser); ok {
+			// add scope hints to minimize the number of auth requests
+			ref, err := repo.ParseReference(src)
+			if err != nil {
+				return ocispec.Descriptor{}, err
+			}
+			ctx = auth.AppendRepositoryScope(ctx, ref, auth.ActionPull, auth.ActionPush)
+		}
+		desc, rc, err := refFetcher.FetchReference(ctx, src)
+		if err != nil {
+			return ocispec.Descriptor{}, err
+		}
+		defer rc.Close()
+		if err := refPusher.PushReference(ctx, desc, rc, dst); err != nil {
+			return ocispec.Descriptor{}, err
+		}
+		return desc, nil
+	}
+
+	desc, err := target.Resolve(ctx, src)
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+	if err := target.Tag(ctx, desc, dst); err != nil {
+		return ocispec.Descriptor{}, err
+	}
+	return desc, nil
+}
+
+// DefaultResolveOptions provides the default ResolveOptions.
+var DefaultResolveOptions ResolveOptions
+
+// ResolveOptions contains parameters for [oras.Resolve].
+type ResolveOptions struct {
+	// TargetPlatform ensures the resolved content matches the target platform
+	// if the node is a manifest, or selects the first resolved content that
+	// matches the target platform if the node is a manifest list.
+	TargetPlatform *ocispec.Platform
+
+	// MaxMetadataBytes limits the maximum size of metadata that can be cached
+	// in the memory.
+	// If less than or equal to 0, a default (currently 4 MiB) is used.
+	MaxMetadataBytes int64
+}
+
+// Resolve resolves a descriptor with provided reference from the target.
+func Resolve(ctx context.Context, target ReadOnlyTarget, reference string, opts ResolveOptions) (ocispec.Descriptor, error) {
+	if opts.TargetPlatform == nil {
+		return target.Resolve(ctx, reference)
+	}
+	return resolve(ctx, target, nil, reference, opts)
+}
+
+// resolve resolves a descriptor with provided reference from the target, with
+// specified caching.
+func resolve(ctx context.Context, target ReadOnlyTarget, proxy *cas.Proxy, reference string, opts ResolveOptions) (ocispec.Descriptor, error) {
+	if opts.MaxMetadataBytes <= 0 {
+		opts.MaxMetadataBytes = defaultResolveMaxMetadataBytes
+	}
+
+	if refFetcher, ok := target.(registry.ReferenceFetcher); ok {
+		// optimize performance for ReferenceFetcher targets
+		desc, rc, err := refFetcher.FetchReference(ctx, reference)
+		if err != nil {
+			return ocispec.Descriptor{}, err
+		}
+		defer rc.Close()
+
+		switch desc.MediaType {
+		case docker.MediaTypeManifestList, ocispec.MediaTypeImageIndex,
+			docker.MediaTypeManifest, ocispec.MediaTypeImageManifest:
+			// cache the fetched content
+			if desc.Size > opts.MaxMetadataBytes {
+				return ocispec.Descriptor{}, fmt.Errorf(
+					"content size %v exceeds MaxMetadataBytes %v: %w",
+					desc.Size,
+					opts.MaxMetadataBytes,
+					errdef.ErrSizeExceedsLimit)
+			}
+			if proxy == nil {
+				proxy = cas.NewProxyWithLimit(target, cas.NewMemory(), opts.MaxMetadataBytes)
+			}
+			if err := proxy.Cache.Push(ctx, desc, rc); err != nil {
+				return ocispec.Descriptor{}, err
+			}
+			// stop caching as SelectManifest may fetch a config blob
+			proxy.StopCaching = true
+			return platform.SelectManifest(ctx, proxy, desc, opts.TargetPlatform)
+		default:
+			return ocispec.Descriptor{}, fmt.Errorf("%s: %s: %w", desc.Digest, desc.MediaType, errdef.ErrUnsupported)
+		}
+	}
+
+	desc, err := target.Resolve(ctx, reference)
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+	return platform.SelectManifest(ctx, target, desc, opts.TargetPlatform)
+}
+
+// DefaultFetchOptions provides the default FetchOptions.
+var DefaultFetchOptions FetchOptions
+
+// FetchOptions contains parameters for [oras.Fetch].
+type FetchOptions struct {
+	// ResolveOptions contains parameters for resolving reference.
+	ResolveOptions
+}
+
+// Fetch fetches the content identified by the reference.
+func Fetch(ctx context.Context, target ReadOnlyTarget, reference string, opts FetchOptions) (ocispec.Descriptor, io.ReadCloser, error) {
+	if opts.TargetPlatform == nil {
+		if refFetcher, ok := target.(registry.ReferenceFetcher); ok {
+			return refFetcher.FetchReference(ctx, reference)
+		}
+
+		desc, err := target.Resolve(ctx, reference)
+		if err != nil {
+			return ocispec.Descriptor{}, nil, err
+		}
+		rc, err := target.Fetch(ctx, desc)
+		if err != nil {
+			return ocispec.Descriptor{}, nil, err
+		}
+		return desc, rc, nil
+	}
+
+	if opts.MaxMetadataBytes <= 0 {
+		opts.MaxMetadataBytes = defaultResolveMaxMetadataBytes
+	}
+	proxy := cas.NewProxyWithLimit(target, cas.NewMemory(), opts.MaxMetadataBytes)
+	desc, err := resolve(ctx, target, proxy, reference, opts.ResolveOptions)
+	if err != nil {
+		return ocispec.Descriptor{}, nil, err
+	}
+	// if the content exists in cache, fetch it from cache
+	// otherwise fetch without caching
+	proxy.StopCaching = true
+	rc, err := proxy.Fetch(ctx, desc)
+	if err != nil {
+		return ocispec.Descriptor{}, nil, err
+	}
+	return desc, rc, nil
+}
+
+// DefaultFetchBytesOptions provides the default FetchBytesOptions.
+var DefaultFetchBytesOptions FetchBytesOptions
+
+// FetchBytesOptions contains parameters for [oras.FetchBytes].
+type FetchBytesOptions struct {
+	// FetchOptions contains parameters for fetching content.
+	FetchOptions
+	// MaxBytes limits the maximum size of the fetched content bytes.
+	// If less than or equal to 0, a default (currently 4 MiB) is used.
+	MaxBytes int64
+}
+
+// FetchBytes fetches the content bytes identified by the reference.
+func FetchBytes(ctx context.Context, target ReadOnlyTarget, reference string, opts FetchBytesOptions) (ocispec.Descriptor, []byte, error) {
+	if opts.MaxBytes <= 0 {
+		opts.MaxBytes = defaultMaxBytes
+	}
+
+	desc, rc, err := Fetch(ctx, target, reference, opts.FetchOptions)
+	if err != nil {
+		return ocispec.Descriptor{}, nil, err
+	}
+	defer rc.Close()
+
+	if desc.Size > opts.MaxBytes {
+		return ocispec.Descriptor{}, nil, fmt.Errorf(
+			"content size %v exceeds MaxBytes %v: %w",
+			desc.Size,
+			opts.MaxBytes,
+			errdef.ErrSizeExceedsLimit)
+	}
+	bytes, err := content.ReadAll(rc, desc)
+	if err != nil {
+		return ocispec.Descriptor{}, nil, err
+	}
+
+	return desc, bytes, nil
+}
+
+// PushBytes describes the contentBytes using the given mediaType and pushes it.
+// If mediaType is not specified, "application/octet-stream" is used.
+func PushBytes(ctx context.Context, pusher content.Pusher, mediaType string, contentBytes []byte) (ocispec.Descriptor, error) {
+	desc := content.NewDescriptorFromBytes(mediaType, contentBytes)
+	r := bytes.NewReader(contentBytes)
+	if err := pusher.Push(ctx, desc, r); err != nil {
+		return ocispec.Descriptor{}, err
+	}
+
+	return desc, nil
+}
+
+// DefaultTagBytesNOptions provides the default TagBytesNOptions.
+var DefaultTagBytesNOptions TagBytesNOptions
+
+// TagBytesNOptions contains parameters for [oras.TagBytesN].
+type TagBytesNOptions struct {
+	// Concurrency limits the maximum number of concurrent tag tasks.
+	// If less than or equal to 0, a default (currently 5) is used.
+	Concurrency int
+}
+
+// TagBytesN describes the contentBytes using the given mediaType, pushes it,
+// and tag it with the given references.
+// If mediaType is not specified, "application/octet-stream" is used.
+func TagBytesN(ctx context.Context, target Target, mediaType string, contentBytes []byte, references []string, opts TagBytesNOptions) (ocispec.Descriptor, error) {
+	if len(references) == 0 {
+		return PushBytes(ctx, target, mediaType, contentBytes)
+	}
+
+	desc := content.NewDescriptorFromBytes(mediaType, contentBytes)
+	if opts.Concurrency <= 0 {
+		opts.Concurrency = defaultTagConcurrency
+	}
+
+	if err := tagBytesN(ctx, target, desc, contentBytes, references, opts); err != nil {
+		return ocispec.Descriptor{}, err
+	}
+	return desc, nil
+}
+
+// tagBytesN pushes the contentBytes using the given desc, and tag it with the
+// given references.
+func tagBytesN(ctx context.Context, target Target, desc ocispec.Descriptor, contentBytes []byte, references []string, opts TagBytesNOptions) error {
+	eg, egCtx := syncutil.LimitGroup(ctx, opts.Concurrency)
+	if refPusher, ok := target.(registry.ReferencePusher); ok {
+		for _, reference := range references {
+			eg.Go(func(ref string) func() error {
+				return func() error {
+					r := bytes.NewReader(contentBytes)
+					if err := refPusher.PushReference(egCtx, desc, r, ref); err != nil && !errors.Is(err, errdef.ErrAlreadyExists) {
+						return fmt.Errorf("failed to tag %s: %w", ref, err)
+					}
+					return nil
+				}
+			}(reference))
+		}
+	} else {
+		r := bytes.NewReader(contentBytes)
+		if err := target.Push(ctx, desc, r); err != nil && !errors.Is(err, errdef.ErrAlreadyExists) {
+			return fmt.Errorf("failed to push content: %w", err)
+		}
+		for _, reference := range references {
+			eg.Go(func(ref string) func() error {
+				return func() error {
+					if err := target.Tag(egCtx, desc, ref); err != nil {
+						return fmt.Errorf("failed to tag %s: %w", ref, err)
+					}
+					return nil
+				}
+			}(reference))
+		}
+	}
+
+	return eg.Wait()
+}
+
+// TagBytes describes the contentBytes using the given mediaType, pushes it,
+// and tag it with the given reference.
+// If mediaType is not specified, "application/octet-stream" is used.
+func TagBytes(ctx context.Context, target Target, mediaType string, contentBytes []byte, reference string) (ocispec.Descriptor, error) {
+	return TagBytesN(ctx, target, mediaType, contentBytes, []string{reference}, DefaultTagBytesNOptions)
+}

--- a/vendor/oras.land/oras-go/v2/copy.go
+++ b/vendor/oras.land/oras-go/v2/copy.go
@@ -1,0 +1,516 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oras
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"golang.org/x/sync/semaphore"
+	"oras.land/oras-go/v2/content"
+	"oras.land/oras-go/v2/errdef"
+	"oras.land/oras-go/v2/internal/cas"
+	"oras.land/oras-go/v2/internal/descriptor"
+	"oras.land/oras-go/v2/internal/platform"
+	"oras.land/oras-go/v2/internal/registryutil"
+	"oras.land/oras-go/v2/internal/status"
+	"oras.land/oras-go/v2/internal/syncutil"
+	"oras.land/oras-go/v2/registry"
+)
+
+// defaultConcurrency is the default value of CopyGraphOptions.Concurrency.
+const defaultConcurrency int = 3 // This value is consistent with dockerd and containerd.
+
+// SkipNode signals to stop copying a node. When returned from PreCopy the blob must exist in the target.
+// This can be used to signal that a blob has been made available in the target repository by "Mount()" or some other technique.
+var SkipNode = errors.New("skip node")
+
+// DefaultCopyOptions provides the default CopyOptions.
+var DefaultCopyOptions CopyOptions = CopyOptions{
+	CopyGraphOptions: DefaultCopyGraphOptions,
+}
+
+// CopyOptions contains parameters for [oras.Copy].
+type CopyOptions struct {
+	CopyGraphOptions
+	// MapRoot maps the resolved root node to a desired root node for copy.
+	// When MapRoot is provided, the descriptor resolved from the source
+	// reference will be passed to MapRoot, and the mapped descriptor will be
+	// used as the root node for copy.
+	MapRoot func(ctx context.Context, src content.ReadOnlyStorage, root ocispec.Descriptor) (ocispec.Descriptor, error)
+}
+
+// WithTargetPlatform configures opts.MapRoot to select the manifest whose
+// platform matches the given platform. When MapRoot is provided, the platform
+// selection will be applied on the mapped root node.
+//   - If the given platform is nil, no platform selection will be applied.
+//   - If the root node is a manifest, it will remain the same if platform
+//     matches, otherwise ErrNotFound will be returned.
+//   - If the root node is a manifest list, it will be mapped to the first
+//     matching manifest if exists, otherwise ErrNotFound will be returned.
+//   - Otherwise ErrUnsupported will be returned.
+func (opts *CopyOptions) WithTargetPlatform(p *ocispec.Platform) {
+	if p == nil {
+		return
+	}
+	mapRoot := opts.MapRoot
+	opts.MapRoot = func(ctx context.Context, src content.ReadOnlyStorage, root ocispec.Descriptor) (desc ocispec.Descriptor, err error) {
+		if mapRoot != nil {
+			if root, err = mapRoot(ctx, src, root); err != nil {
+				return ocispec.Descriptor{}, err
+			}
+		}
+		return platform.SelectManifest(ctx, src, root, p)
+	}
+}
+
+// defaultCopyMaxMetadataBytes is the default value of
+// CopyGraphOptions.MaxMetadataBytes.
+const defaultCopyMaxMetadataBytes int64 = 4 * 1024 * 1024 // 4 MiB
+
+// DefaultCopyGraphOptions provides the default CopyGraphOptions.
+var DefaultCopyGraphOptions CopyGraphOptions
+
+// CopyGraphOptions contains parameters for [oras.CopyGraph].
+type CopyGraphOptions struct {
+	// Concurrency limits the maximum number of concurrent copy tasks.
+	// If less than or equal to 0, a default (currently 3) is used.
+	Concurrency int
+	// MaxMetadataBytes limits the maximum size of the metadata that can be
+	// cached in the memory.
+	// If less than or equal to 0, a default (currently 4 MiB) is used.
+	MaxMetadataBytes int64
+	// PreCopy handles the current descriptor before it is copied. PreCopy can
+	// return a SkipNode to signal that desc should be skipped when it already
+	// exists in the target.
+	PreCopy func(ctx context.Context, desc ocispec.Descriptor) error
+	// PostCopy handles the current descriptor after it is copied.
+	PostCopy func(ctx context.Context, desc ocispec.Descriptor) error
+	// OnCopySkipped will be called when the sub-DAG rooted by the current node
+	// is skipped.
+	OnCopySkipped func(ctx context.Context, desc ocispec.Descriptor) error
+	// MountFrom returns the candidate repositories that desc may be mounted from.
+	// The OCI references will be tried in turn.  If mounting fails on all of them,
+	// then it falls back to a copy.
+	MountFrom func(ctx context.Context, desc ocispec.Descriptor) ([]string, error)
+	// OnMounted will be invoked when desc is mounted.
+	OnMounted func(ctx context.Context, desc ocispec.Descriptor) error
+	// FindSuccessors finds the successors of the current node.
+	// fetcher provides cached access to the source storage, and is suitable
+	// for fetching non-leaf nodes like manifests. Since anything fetched from
+	// fetcher will be cached in the memory, it is recommended to use original
+	// source storage to fetch large blobs.
+	// If FindSuccessors is nil, content.Successors will be used.
+	FindSuccessors func(ctx context.Context, fetcher content.Fetcher, desc ocispec.Descriptor) ([]ocispec.Descriptor, error)
+}
+
+// Copy copies a rooted directed acyclic graph (DAG) with the tagged root node
+// in the source Target to the destination Target.
+// The destination reference will be the same as the source reference if the
+// destination reference is left blank.
+//
+// Returns the descriptor of the root node on successful copy.
+func Copy(ctx context.Context, src ReadOnlyTarget, srcRef string, dst Target, dstRef string, opts CopyOptions) (ocispec.Descriptor, error) {
+	if src == nil {
+		return ocispec.Descriptor{}, errors.New("nil source target")
+	}
+	if dst == nil {
+		return ocispec.Descriptor{}, errors.New("nil destination target")
+	}
+	if dstRef == "" {
+		dstRef = srcRef
+	}
+
+	// use caching proxy on non-leaf nodes
+	if opts.MaxMetadataBytes <= 0 {
+		opts.MaxMetadataBytes = defaultCopyMaxMetadataBytes
+	}
+	proxy := cas.NewProxyWithLimit(src, cas.NewMemory(), opts.MaxMetadataBytes)
+	root, err := resolveRoot(ctx, src, srcRef, proxy)
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("failed to resolve %s: %w", srcRef, err)
+	}
+
+	if opts.MapRoot != nil {
+		proxy.StopCaching = true
+		root, err = opts.MapRoot(ctx, proxy, root)
+		if err != nil {
+			return ocispec.Descriptor{}, err
+		}
+		proxy.StopCaching = false
+	}
+
+	if err := prepareCopy(ctx, dst, dstRef, proxy, root, &opts); err != nil {
+		return ocispec.Descriptor{}, err
+	}
+
+	if err := copyGraph(ctx, src, dst, root, proxy, nil, nil, opts.CopyGraphOptions); err != nil {
+		return ocispec.Descriptor{}, err
+	}
+
+	return root, nil
+}
+
+// CopyGraph copies a rooted directed acyclic graph (DAG) from the source CAS to
+// the destination CAS.
+func CopyGraph(ctx context.Context, src content.ReadOnlyStorage, dst content.Storage, root ocispec.Descriptor, opts CopyGraphOptions) error {
+	return copyGraph(ctx, src, dst, root, nil, nil, nil, opts)
+}
+
+// copyGraph copies a rooted directed acyclic graph (DAG) from the source CAS to
+// the destination CAS with specified caching, concurrency limiter and tracker.
+func copyGraph(ctx context.Context, src content.ReadOnlyStorage, dst content.Storage, root ocispec.Descriptor,
+	proxy *cas.Proxy, limiter *semaphore.Weighted, tracker *status.Tracker, opts CopyGraphOptions) error {
+	if proxy == nil {
+		// use caching proxy on non-leaf nodes
+		if opts.MaxMetadataBytes <= 0 {
+			opts.MaxMetadataBytes = defaultCopyMaxMetadataBytes
+		}
+		proxy = cas.NewProxyWithLimit(src, cas.NewMemory(), opts.MaxMetadataBytes)
+	}
+	if limiter == nil {
+		// if Concurrency is not set or invalid, use the default concurrency
+		if opts.Concurrency <= 0 {
+			opts.Concurrency = defaultConcurrency
+		}
+		limiter = semaphore.NewWeighted(int64(opts.Concurrency))
+	}
+	if tracker == nil {
+		// track content status
+		tracker = status.NewTracker()
+	}
+	// if FindSuccessors is not provided, use the default one
+	if opts.FindSuccessors == nil {
+		opts.FindSuccessors = content.Successors
+	}
+
+	// traverse the graph
+	var fn syncutil.GoFunc[ocispec.Descriptor]
+	fn = func(ctx context.Context, region *syncutil.LimitedRegion, desc ocispec.Descriptor) (err error) {
+		// skip the descriptor if other go routine is working on it
+		done, committed := tracker.TryCommit(desc)
+		if !committed {
+			return nil
+		}
+		defer func() {
+			if err == nil {
+				// mark the content as done on success
+				close(done)
+			}
+		}()
+
+		// skip if a rooted sub-DAG exists
+		exists, err := dst.Exists(ctx, desc)
+		if err != nil {
+			return err
+		}
+		if exists {
+			if opts.OnCopySkipped != nil {
+				if err := opts.OnCopySkipped(ctx, desc); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+
+		// find successors while non-leaf nodes will be fetched and cached
+		successors, err := opts.FindSuccessors(ctx, proxy, desc)
+		if err != nil {
+			return err
+		}
+		successors = removeForeignLayers(successors)
+
+		if len(successors) != 0 {
+			// for non-leaf nodes, process successors and wait for them to complete
+			region.End()
+			if err := syncutil.Go(ctx, limiter, fn, successors...); err != nil {
+				return err
+			}
+			for _, node := range successors {
+				done, committed := tracker.TryCommit(node)
+				if committed {
+					return fmt.Errorf("%s: %s: successor not committed", desc.Digest, node.Digest)
+				}
+				select {
+				case <-done:
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			}
+			if err := region.Start(); err != nil {
+				return err
+			}
+		}
+
+		exists, err = proxy.Cache.Exists(ctx, desc)
+		if err != nil {
+			return err
+		}
+		if exists {
+			return copyNode(ctx, proxy.Cache, dst, desc, opts)
+		}
+		return mountOrCopyNode(ctx, src, dst, desc, opts)
+	}
+
+	return syncutil.Go(ctx, limiter, fn, root)
+}
+
+// mountOrCopyNode tries to mount the node, if not falls back to copying.
+func mountOrCopyNode(ctx context.Context, src content.ReadOnlyStorage, dst content.Storage, desc ocispec.Descriptor, opts CopyGraphOptions) error {
+	// Need MountFrom and it must be a blob
+	if opts.MountFrom == nil || descriptor.IsManifest(desc) {
+		return copyNode(ctx, src, dst, desc, opts)
+	}
+
+	mounter, ok := dst.(registry.Mounter)
+	if !ok {
+		// mounting is not supported by the destination
+		return copyNode(ctx, src, dst, desc, opts)
+	}
+
+	sourceRepositories, err := opts.MountFrom(ctx, desc)
+	if err != nil {
+		// Technically this error is not fatal, we can still attempt to copy the node
+		// But for consistency with the other callbacks we bail out.
+		return err
+	}
+
+	if len(sourceRepositories) == 0 {
+		return copyNode(ctx, src, dst, desc, opts)
+	}
+
+	skipSource := errors.New("skip source")
+	for i, sourceRepository := range sourceRepositories {
+		// try mounting this source repository
+		var mountFailed bool
+		getContent := func() (io.ReadCloser, error) {
+			// the invocation of getContent indicates that mounting has failed
+			mountFailed = true
+
+			if i < len(sourceRepositories)-1 {
+				// If this is not the last one, skip this source and try next one
+				// We want to return an error that we will test for from mounter.Mount()
+				return nil, skipSource
+			}
+			// this is the last iteration so we need to actually get the content and do the copy
+			// but first call the PreCopy function
+			if opts.PreCopy != nil {
+				if err := opts.PreCopy(ctx, desc); err != nil {
+					return nil, err
+				}
+			}
+			return src.Fetch(ctx, desc)
+		}
+
+		// Mount or copy
+		if err := mounter.Mount(ctx, desc, sourceRepository, getContent); err != nil && !errors.Is(err, skipSource) {
+			return err
+		}
+
+		if !mountFailed {
+			// mounted, success
+			if opts.OnMounted != nil {
+				if err := opts.OnMounted(ctx, desc); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+	}
+
+	// we copied it
+	if opts.PostCopy != nil {
+		if err := opts.PostCopy(ctx, desc); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// doCopyNode copies a single content from the source CAS to the destination CAS.
+func doCopyNode(ctx context.Context, src content.ReadOnlyStorage, dst content.Storage, desc ocispec.Descriptor) error {
+	rc, err := src.Fetch(ctx, desc)
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+	err = dst.Push(ctx, desc, rc)
+	if err != nil && !errors.Is(err, errdef.ErrAlreadyExists) {
+		return err
+	}
+	return nil
+}
+
+// copyNode copies a single content from the source CAS to the destination CAS,
+// and apply the given options.
+func copyNode(ctx context.Context, src content.ReadOnlyStorage, dst content.Storage, desc ocispec.Descriptor, opts CopyGraphOptions) error {
+	if opts.PreCopy != nil {
+		if err := opts.PreCopy(ctx, desc); err != nil {
+			if err == SkipNode {
+				return nil
+			}
+			return err
+		}
+	}
+
+	if err := doCopyNode(ctx, src, dst, desc); err != nil {
+		return err
+	}
+
+	if opts.PostCopy != nil {
+		return opts.PostCopy(ctx, desc)
+	}
+	return nil
+}
+
+// copyCachedNodeWithReference copies a single content with a reference from the
+// source cache to the destination ReferencePusher.
+func copyCachedNodeWithReference(ctx context.Context, src *cas.Proxy, dst registry.ReferencePusher, desc ocispec.Descriptor, dstRef string) error {
+	rc, err := src.FetchCached(ctx, desc)
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+
+	err = dst.PushReference(ctx, desc, rc, dstRef)
+	if err != nil && !errors.Is(err, errdef.ErrAlreadyExists) {
+		return err
+	}
+	return nil
+}
+
+// resolveRoot resolves the source reference to the root node.
+func resolveRoot(ctx context.Context, src ReadOnlyTarget, srcRef string, proxy *cas.Proxy) (ocispec.Descriptor, error) {
+	refFetcher, ok := src.(registry.ReferenceFetcher)
+	if !ok {
+		return src.Resolve(ctx, srcRef)
+	}
+
+	// optimize performance for ReferenceFetcher targets
+	refProxy := &registryutil.Proxy{
+		ReferenceFetcher: refFetcher,
+		Proxy:            proxy,
+	}
+	root, rc, err := refProxy.FetchReference(ctx, srcRef)
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+	defer rc.Close()
+	// cache root if it is a non-leaf node
+	fetcher := content.FetcherFunc(func(ctx context.Context, target ocispec.Descriptor) (io.ReadCloser, error) {
+		if content.Equal(target, root) {
+			return rc, nil
+		}
+		return nil, errors.New("fetching only root node expected")
+	})
+	if _, err = content.Successors(ctx, fetcher, root); err != nil {
+		return ocispec.Descriptor{}, err
+	}
+
+	// TODO: optimize special case where root is a leaf node (i.e. a blob)
+	//       and dst is a ReferencePusher.
+	return root, nil
+}
+
+// prepareCopy prepares the hooks for copy.
+func prepareCopy(ctx context.Context, dst Target, dstRef string, proxy *cas.Proxy, root ocispec.Descriptor, opts *CopyOptions) error {
+	if refPusher, ok := dst.(registry.ReferencePusher); ok {
+		// optimize performance for ReferencePusher targets
+		preCopy := opts.PreCopy
+		opts.PreCopy = func(ctx context.Context, desc ocispec.Descriptor) error {
+			if preCopy != nil {
+				if err := preCopy(ctx, desc); err != nil {
+					return err
+				}
+			}
+			if !content.Equal(desc, root) {
+				// for non-root node, do nothing
+				return nil
+			}
+
+			// for root node, prepare optimized copy
+			if err := copyCachedNodeWithReference(ctx, proxy, refPusher, desc, dstRef); err != nil {
+				return err
+			}
+			if opts.PostCopy != nil {
+				if err := opts.PostCopy(ctx, desc); err != nil {
+					return err
+				}
+			}
+			// skip the regular copy workflow
+			return SkipNode
+		}
+	} else {
+		postCopy := opts.PostCopy
+		opts.PostCopy = func(ctx context.Context, desc ocispec.Descriptor) error {
+			if content.Equal(desc, root) {
+				// for root node, tag it after copying it
+				if err := dst.Tag(ctx, root, dstRef); err != nil {
+					return err
+				}
+			}
+			if postCopy != nil {
+				return postCopy(ctx, desc)
+			}
+			return nil
+		}
+	}
+
+	onCopySkipped := opts.OnCopySkipped
+	opts.OnCopySkipped = func(ctx context.Context, desc ocispec.Descriptor) error {
+		if !content.Equal(desc, root) {
+			if onCopySkipped != nil {
+				return onCopySkipped(ctx, desc)
+			}
+			return nil
+		}
+
+		// enforce tagging when the skipped node is root
+		if refPusher, ok := dst.(registry.ReferencePusher); ok {
+			// NOTE: refPusher tags the node by copying it with the reference,
+			// so onCopySkipped shouldn't be invoked in this case
+			return copyCachedNodeWithReference(ctx, proxy, refPusher, desc, dstRef)
+		}
+
+		// invoke onCopySkipped before tagging
+		if onCopySkipped != nil {
+			if err := onCopySkipped(ctx, desc); err != nil {
+				return err
+			}
+		}
+		return dst.Tag(ctx, root, dstRef)
+	}
+
+	return nil
+}
+
+// removeForeignLayers in-place removes all foreign layers in the given slice.
+func removeForeignLayers(descs []ocispec.Descriptor) []ocispec.Descriptor {
+	var j int
+	for i, desc := range descs {
+		if !descriptor.IsForeignLayer(desc) {
+			if i != j {
+				descs[j] = desc
+			}
+			j++
+		}
+	}
+	return descs[:j]
+}

--- a/vendor/oras.land/oras-go/v2/extendedcopy.go
+++ b/vendor/oras.land/oras-go/v2/extendedcopy.go
@@ -1,0 +1,389 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oras
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"regexp"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"golang.org/x/sync/semaphore"
+	"oras.land/oras-go/v2/content"
+	"oras.land/oras-go/v2/internal/cas"
+	"oras.land/oras-go/v2/internal/container/set"
+	"oras.land/oras-go/v2/internal/copyutil"
+	"oras.land/oras-go/v2/internal/descriptor"
+	"oras.land/oras-go/v2/internal/docker"
+	"oras.land/oras-go/v2/internal/spec"
+	"oras.land/oras-go/v2/internal/status"
+	"oras.land/oras-go/v2/internal/syncutil"
+	"oras.land/oras-go/v2/registry"
+)
+
+// DefaultExtendedCopyOptions provides the default ExtendedCopyOptions.
+var DefaultExtendedCopyOptions ExtendedCopyOptions = ExtendedCopyOptions{
+	ExtendedCopyGraphOptions: DefaultExtendedCopyGraphOptions,
+}
+
+// ExtendedCopyOptions contains parameters for [oras.ExtendedCopy].
+type ExtendedCopyOptions struct {
+	ExtendedCopyGraphOptions
+}
+
+// DefaultExtendedCopyGraphOptions provides the default ExtendedCopyGraphOptions.
+var DefaultExtendedCopyGraphOptions ExtendedCopyGraphOptions = ExtendedCopyGraphOptions{
+	CopyGraphOptions: DefaultCopyGraphOptions,
+}
+
+// ExtendedCopyGraphOptions contains parameters for [oras.ExtendedCopyGraph].
+type ExtendedCopyGraphOptions struct {
+	CopyGraphOptions
+	// Depth limits the maximum depth of the directed acyclic graph (DAG) that
+	// will be extended-copied.
+	// If Depth is no specified, or the specified value is less than or
+	// equal to 0, the depth limit will be considered as infinity.
+	Depth int
+	// FindPredecessors finds the predecessors of the current node.
+	// If FindPredecessors is nil, src.Predecessors will be adapted and used.
+	FindPredecessors func(ctx context.Context, src content.ReadOnlyGraphStorage, desc ocispec.Descriptor) ([]ocispec.Descriptor, error)
+}
+
+// ExtendedCopy copies the directed acyclic graph (DAG) that are reachable from
+// the given tagged node from the source GraphTarget to the destination Target.
+// The destination reference will be the same as the source reference if the
+// destination reference is left blank.
+//
+// Returns the descriptor of the tagged node on successful copy.
+func ExtendedCopy(ctx context.Context, src ReadOnlyGraphTarget, srcRef string, dst Target, dstRef string, opts ExtendedCopyOptions) (ocispec.Descriptor, error) {
+	if src == nil {
+		return ocispec.Descriptor{}, errors.New("nil source graph target")
+	}
+	if dst == nil {
+		return ocispec.Descriptor{}, errors.New("nil destination target")
+	}
+	if dstRef == "" {
+		dstRef = srcRef
+	}
+
+	node, err := src.Resolve(ctx, srcRef)
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+
+	if err := ExtendedCopyGraph(ctx, src, dst, node, opts.ExtendedCopyGraphOptions); err != nil {
+		return ocispec.Descriptor{}, err
+	}
+
+	if err := dst.Tag(ctx, node, dstRef); err != nil {
+		return ocispec.Descriptor{}, err
+	}
+
+	return node, nil
+}
+
+// ExtendedCopyGraph copies the directed acyclic graph (DAG) that are reachable
+// from the given node from the source GraphStorage to the destination Storage.
+func ExtendedCopyGraph(ctx context.Context, src content.ReadOnlyGraphStorage, dst content.Storage, node ocispec.Descriptor, opts ExtendedCopyGraphOptions) error {
+	roots, err := findRoots(ctx, src, node, opts)
+	if err != nil {
+		return err
+	}
+
+	// if Concurrency is not set or invalid, use the default concurrency
+	if opts.Concurrency <= 0 {
+		opts.Concurrency = defaultConcurrency
+	}
+	limiter := semaphore.NewWeighted(int64(opts.Concurrency))
+	// use caching proxy on non-leaf nodes
+	if opts.MaxMetadataBytes <= 0 {
+		opts.MaxMetadataBytes = defaultCopyMaxMetadataBytes
+	}
+	proxy := cas.NewProxyWithLimit(src, cas.NewMemory(), opts.MaxMetadataBytes)
+	// track content status
+	tracker := status.NewTracker()
+
+	// copy the sub-DAGs rooted by the root nodes
+	return syncutil.Go(ctx, limiter, func(ctx context.Context, region *syncutil.LimitedRegion, root ocispec.Descriptor) error {
+		// As a root can be a predecessor of other roots, release the limit here
+		// for dispatching, to avoid dead locks where predecessor roots are
+		// handled first and are waiting for its successors to complete.
+		region.End()
+		if err := copyGraph(ctx, src, dst, root, proxy, limiter, tracker, opts.CopyGraphOptions); err != nil {
+			return err
+		}
+		return region.Start()
+	}, roots...)
+}
+
+// findRoots finds the root nodes reachable from the given node through a
+// depth-first search.
+func findRoots(ctx context.Context, storage content.ReadOnlyGraphStorage, node ocispec.Descriptor, opts ExtendedCopyGraphOptions) ([]ocispec.Descriptor, error) {
+	visited := set.New[descriptor.Descriptor]()
+	rootMap := make(map[descriptor.Descriptor]ocispec.Descriptor)
+	addRoot := func(key descriptor.Descriptor, val ocispec.Descriptor) {
+		if _, exists := rootMap[key]; !exists {
+			rootMap[key] = val
+		}
+	}
+
+	// if FindPredecessors is not provided, use the default one
+	if opts.FindPredecessors == nil {
+		opts.FindPredecessors = func(ctx context.Context, src content.ReadOnlyGraphStorage, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+			return src.Predecessors(ctx, desc)
+		}
+	}
+
+	var stack copyutil.Stack
+	// push the initial node to the stack, set the depth to 0
+	stack.Push(copyutil.NodeInfo{Node: node, Depth: 0})
+	for {
+		current, ok := stack.Pop()
+		if !ok {
+			// empty stack
+			break
+		}
+		currentNode := current.Node
+		currentKey := descriptor.FromOCI(currentNode)
+
+		if visited.Contains(currentKey) {
+			// skip the current node if it has been visited
+			continue
+		}
+		visited.Add(currentKey)
+
+		// stop finding predecessors if the target depth is reached
+		if opts.Depth > 0 && current.Depth == opts.Depth {
+			addRoot(currentKey, currentNode)
+			continue
+		}
+
+		predecessors, err := opts.FindPredecessors(ctx, storage, currentNode)
+		if err != nil {
+			return nil, err
+		}
+
+		// The current node has no predecessor node,
+		// which means it is a root node of a sub-DAG.
+		if len(predecessors) == 0 {
+			addRoot(currentKey, currentNode)
+			continue
+		}
+
+		// The current node has predecessor nodes, which means it is NOT a root node.
+		// Push the predecessor nodes to the stack and keep finding from there.
+		for _, predecessor := range predecessors {
+			predecessorKey := descriptor.FromOCI(predecessor)
+			if !visited.Contains(predecessorKey) {
+				// push the predecessor node with increased depth
+				stack.Push(copyutil.NodeInfo{Node: predecessor, Depth: current.Depth + 1})
+			}
+		}
+	}
+
+	roots := make([]ocispec.Descriptor, 0, len(rootMap))
+	for _, root := range rootMap {
+		roots = append(roots, root)
+	}
+	return roots, nil
+}
+
+// FilterAnnotation configures opts.FindPredecessors to filter the predecessors
+// whose annotation matches a given regex pattern.
+//
+// A predecessor is kept if key is in its annotations and the annotation value
+// matches regex.
+// If regex is nil, predecessors whose annotations contain key will be kept,
+// no matter of the annotation value.
+//
+// For performance consideration, when using both FilterArtifactType and
+// FilterAnnotation, it's recommended to call FilterArtifactType first.
+func (opts *ExtendedCopyGraphOptions) FilterAnnotation(key string, regex *regexp.Regexp) {
+	keep := func(desc ocispec.Descriptor) bool {
+		value, ok := desc.Annotations[key]
+		return ok && (regex == nil || regex.MatchString(value))
+	}
+
+	fp := opts.FindPredecessors
+	opts.FindPredecessors = func(ctx context.Context, src content.ReadOnlyGraphStorage, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+		var predecessors []ocispec.Descriptor
+		var err error
+		if fp == nil {
+			if rf, ok := src.(registry.ReferrerLister); ok {
+				// if src is a ReferrerLister, use Referrers() for possible memory saving
+				if err := rf.Referrers(ctx, desc, "", func(referrers []ocispec.Descriptor) error {
+					// for each page of the results, filter the referrers
+					for _, r := range referrers {
+						if keep(r) {
+							predecessors = append(predecessors, r)
+						}
+					}
+					return nil
+				}); err != nil {
+					return nil, err
+				}
+				return predecessors, nil
+			}
+			predecessors, err = src.Predecessors(ctx, desc)
+		} else {
+			predecessors, err = fp(ctx, src, desc)
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		// Predecessor descriptors that are not from Referrers API are not
+		// guaranteed to include the annotations of the corresponding manifests.
+		var kept []ocispec.Descriptor
+		for _, p := range predecessors {
+			if p.Annotations == nil {
+				// If the annotations are not present in the descriptors,
+				// fetch it from the manifest content.
+				switch p.MediaType {
+				case docker.MediaTypeManifest, ocispec.MediaTypeImageManifest,
+					docker.MediaTypeManifestList, ocispec.MediaTypeImageIndex,
+					spec.MediaTypeArtifactManifest:
+					annotations, err := fetchAnnotations(ctx, src, p)
+					if err != nil {
+						return nil, err
+					}
+					p.Annotations = annotations
+				}
+			}
+			if keep(p) {
+				kept = append(kept, p)
+			}
+		}
+		return kept, nil
+	}
+}
+
+// fetchAnnotations fetches the annotations of the manifest described by desc.
+func fetchAnnotations(ctx context.Context, src content.ReadOnlyGraphStorage, desc ocispec.Descriptor) (map[string]string, error) {
+	rc, err := src.Fetch(ctx, desc)
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+
+	var manifest struct {
+		Annotations map[string]string `json:"annotations"`
+	}
+	if err := json.NewDecoder(rc).Decode(&manifest); err != nil {
+		return nil, err
+	}
+	if manifest.Annotations == nil {
+		// to differentiate with nil
+		return make(map[string]string), nil
+	}
+	return manifest.Annotations, nil
+}
+
+// FilterArtifactType configures opts.FindPredecessors to filter the
+// predecessors whose artifact type matches a given regex pattern.
+//
+// A predecessor is kept if its artifact type matches regex.
+// If regex is nil, all predecessors will be kept.
+//
+// For performance consideration, when using both FilterArtifactType and
+// FilterAnnotation, it's recommended to call FilterArtifactType first.
+func (opts *ExtendedCopyGraphOptions) FilterArtifactType(regex *regexp.Regexp) {
+	if regex == nil {
+		return
+	}
+	keep := func(desc ocispec.Descriptor) bool {
+		return regex.MatchString(desc.ArtifactType)
+	}
+
+	fp := opts.FindPredecessors
+	opts.FindPredecessors = func(ctx context.Context, src content.ReadOnlyGraphStorage, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+		var predecessors []ocispec.Descriptor
+		var err error
+		if fp == nil {
+			if rf, ok := src.(registry.ReferrerLister); ok {
+				// if src is a ReferrerLister, use Referrers() for possible memory saving
+				if err := rf.Referrers(ctx, desc, "", func(referrers []ocispec.Descriptor) error {
+					// for each page of the results, filter the referrers
+					for _, r := range referrers {
+						if keep(r) {
+							predecessors = append(predecessors, r)
+						}
+					}
+					return nil
+				}); err != nil {
+					return nil, err
+				}
+				return predecessors, nil
+			}
+			predecessors, err = src.Predecessors(ctx, desc)
+		} else {
+			predecessors, err = fp(ctx, src, desc)
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		// predecessor descriptors that are not from Referrers API are not
+		// guaranteed to include the artifact type of the corresponding
+		// manifests.
+		var kept []ocispec.Descriptor
+		for _, p := range predecessors {
+			if p.ArtifactType == "" {
+				// if the artifact type is not present in the descriptors,
+				// fetch it from the manifest content.
+				switch p.MediaType {
+				case spec.MediaTypeArtifactManifest, ocispec.MediaTypeImageManifest:
+					artifactType, err := fetchArtifactType(ctx, src, p)
+					if err != nil {
+						return nil, err
+					}
+					p.ArtifactType = artifactType
+				}
+			}
+			if keep(p) {
+				kept = append(kept, p)
+			}
+		}
+		return kept, nil
+	}
+}
+
+// fetchArtifactType fetches the artifact type of the manifest described by desc.
+func fetchArtifactType(ctx context.Context, src content.ReadOnlyGraphStorage, desc ocispec.Descriptor) (string, error) {
+	rc, err := src.Fetch(ctx, desc)
+	if err != nil {
+		return "", err
+	}
+	defer rc.Close()
+
+	switch desc.MediaType {
+	case spec.MediaTypeArtifactManifest:
+		var manifest spec.Artifact
+		if err := json.NewDecoder(rc).Decode(&manifest); err != nil {
+			return "", err
+		}
+		return manifest.ArtifactType, nil
+	case ocispec.MediaTypeImageManifest:
+		var manifest ocispec.Manifest
+		if err := json.NewDecoder(rc).Decode(&manifest); err != nil {
+			return "", err
+		}
+		return manifest.Config.MediaType, nil
+	default:
+		return "", nil
+	}
+}

--- a/vendor/oras.land/oras-go/v2/internal/container/set/set.go
+++ b/vendor/oras.land/oras-go/v2/internal/container/set/set.go
@@ -1,0 +1,40 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package set
+
+// Set represents a set data structure.
+type Set[T comparable] map[T]struct{}
+
+// New returns an initialized set.
+func New[T comparable]() Set[T] {
+	return make(Set[T])
+}
+
+// Add adds item into the set s.
+func (s Set[T]) Add(item T) {
+	s[item] = struct{}{}
+}
+
+// Contains returns true if the set s contains item.
+func (s Set[T]) Contains(item T) bool {
+	_, ok := s[item]
+	return ok
+}
+
+// Delete deletes an item from the set.
+func (s Set[T]) Delete(item T) {
+	delete(s, item)
+}

--- a/vendor/oras.land/oras-go/v2/internal/copyutil/stack.go
+++ b/vendor/oras.land/oras-go/v2/internal/copyutil/stack.go
@@ -1,0 +1,55 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package copyutil
+
+import (
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// NodeInfo represents information of a node that is being visited in
+// ExtendedCopy.
+type NodeInfo struct {
+	// Node represents a node in the graph.
+	Node ocispec.Descriptor
+	// Depth represents the depth of the node in the graph.
+	Depth int
+}
+
+// Stack represents a stack data structure that is used in ExtendedCopy for
+// storing node information.
+type Stack []NodeInfo
+
+// IsEmpty returns true if the stack is empty, otherwise returns false.
+func (s *Stack) IsEmpty() bool {
+	return len(*s) == 0
+}
+
+// Push pushes an item to the stack.
+func (s *Stack) Push(i NodeInfo) {
+	*s = append(*s, i)
+}
+
+// Pop pops the top item out of the stack.
+func (s *Stack) Pop() (NodeInfo, bool) {
+	if s.IsEmpty() {
+		return NodeInfo{}, false
+	}
+
+	last := len(*s) - 1
+	top := (*s)[last]
+	*s = (*s)[:last]
+	return top, true
+}

--- a/vendor/oras.land/oras-go/v2/internal/interfaces/registry.go
+++ b/vendor/oras.land/oras-go/v2/internal/interfaces/registry.go
@@ -1,0 +1,24 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package interfaces
+
+import "oras.land/oras-go/v2/registry"
+
+// ReferenceParser provides reference parsing.
+type ReferenceParser interface {
+	// ParseReference parses a reference to a fully qualified reference.
+	ParseReference(reference string) (registry.Reference, error)
+}

--- a/vendor/oras.land/oras-go/v2/internal/manifestutil/parser.go
+++ b/vendor/oras.land/oras-go/v2/internal/manifestutil/parser.go
@@ -1,0 +1,84 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manifestutil
+
+import (
+	"context"
+	"encoding/json"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/content"
+	"oras.land/oras-go/v2/internal/docker"
+	"oras.land/oras-go/v2/internal/spec"
+)
+
+// Config returns the config of desc, if present.
+func Config(ctx context.Context, fetcher content.Fetcher, desc ocispec.Descriptor) (*ocispec.Descriptor, error) {
+	switch desc.MediaType {
+	case docker.MediaTypeManifest, ocispec.MediaTypeImageManifest:
+		content, err := content.FetchAll(ctx, fetcher, desc)
+		if err != nil {
+			return nil, err
+		}
+		// OCI manifest schema can be used to marshal docker manifest
+		var manifest ocispec.Manifest
+		if err := json.Unmarshal(content, &manifest); err != nil {
+			return nil, err
+		}
+		return &manifest.Config, nil
+	default:
+		return nil, nil
+	}
+}
+
+// Manifest returns the manifests of desc, if present.
+func Manifests(ctx context.Context, fetcher content.Fetcher, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+	switch desc.MediaType {
+	case docker.MediaTypeManifestList, ocispec.MediaTypeImageIndex:
+		content, err := content.FetchAll(ctx, fetcher, desc)
+		if err != nil {
+			return nil, err
+		}
+		// OCI manifest index schema can be used to marshal docker manifest list
+		var index ocispec.Index
+		if err := json.Unmarshal(content, &index); err != nil {
+			return nil, err
+		}
+		return index.Manifests, nil
+	default:
+		return nil, nil
+	}
+}
+
+// Subject returns the subject of desc, if present.
+func Subject(ctx context.Context, fetcher content.Fetcher, desc ocispec.Descriptor) (*ocispec.Descriptor, error) {
+	switch desc.MediaType {
+	case ocispec.MediaTypeImageManifest, ocispec.MediaTypeImageIndex, spec.MediaTypeArtifactManifest:
+		content, err := content.FetchAll(ctx, fetcher, desc)
+		if err != nil {
+			return nil, err
+		}
+		var manifest struct {
+			Subject *ocispec.Descriptor `json:"subject,omitempty"`
+		}
+		if err := json.Unmarshal(content, &manifest); err != nil {
+			return nil, err
+		}
+		return manifest.Subject, nil
+	default:
+		return nil, nil
+	}
+}

--- a/vendor/oras.land/oras-go/v2/internal/platform/platform.go
+++ b/vendor/oras.land/oras-go/v2/internal/platform/platform.go
@@ -1,0 +1,145 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package platform
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/content"
+	"oras.land/oras-go/v2/errdef"
+	"oras.land/oras-go/v2/internal/docker"
+	"oras.land/oras-go/v2/internal/manifestutil"
+)
+
+// Match checks whether the current platform matches the target platform.
+// Match will return true if all of the following conditions are met.
+//   - Architecture and OS exactly match.
+//   - Variant and OSVersion exactly match if target platform provided.
+//   - OSFeatures of the target platform are the subsets of the OSFeatures
+//     array of the current platform.
+//
+// Note: Variant, OSVersion and OSFeatures are optional fields, will skip
+// the comparison if the target platform does not provide specific value.
+func Match(got *ocispec.Platform, want *ocispec.Platform) bool {
+	if got == nil && want == nil {
+		return true
+	}
+
+	if got == nil || want == nil {
+		return false
+	}
+
+	if got.Architecture != want.Architecture || got.OS != want.OS {
+		return false
+	}
+
+	if want.OSVersion != "" && got.OSVersion != want.OSVersion {
+		return false
+	}
+
+	if want.Variant != "" && got.Variant != want.Variant {
+		return false
+	}
+
+	if len(want.OSFeatures) != 0 && !isSubset(want.OSFeatures, got.OSFeatures) {
+		return false
+	}
+
+	return true
+}
+
+// isSubset returns true if all items in slice A are present in slice B.
+func isSubset(a, b []string) bool {
+	set := make(map[string]bool, len(b))
+	for _, v := range b {
+		set[v] = true
+	}
+	for _, v := range a {
+		if _, ok := set[v]; !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
+// SelectManifest implements platform filter and returns the descriptor of the
+// first matched manifest if the root is a manifest list. If the root is a
+// manifest, then return the root descriptor if platform matches.
+func SelectManifest(ctx context.Context, src content.ReadOnlyStorage, root ocispec.Descriptor, p *ocispec.Platform) (ocispec.Descriptor, error) {
+	switch root.MediaType {
+	case docker.MediaTypeManifestList, ocispec.MediaTypeImageIndex:
+		manifests, err := manifestutil.Manifests(ctx, src, root)
+		if err != nil {
+			return ocispec.Descriptor{}, err
+		}
+
+		// platform filter
+		for _, m := range manifests {
+			if Match(m.Platform, p) {
+				return m, nil
+			}
+		}
+		return ocispec.Descriptor{}, fmt.Errorf("%s: %w: no matching manifest was found in the manifest list", root.Digest, errdef.ErrNotFound)
+	case docker.MediaTypeManifest, ocispec.MediaTypeImageManifest:
+		// config will be non-nil for docker manifest and OCI image manifest
+		config, err := manifestutil.Config(ctx, src, root)
+		if err != nil {
+			return ocispec.Descriptor{}, err
+		}
+
+		configMediaType := docker.MediaTypeConfig
+		if root.MediaType == ocispec.MediaTypeImageManifest {
+			configMediaType = ocispec.MediaTypeImageConfig
+		}
+		cfgPlatform, err := getPlatformFromConfig(ctx, src, *config, configMediaType)
+		if err != nil {
+			return ocispec.Descriptor{}, err
+		}
+
+		if Match(cfgPlatform, p) {
+			return root, nil
+		}
+		return ocispec.Descriptor{}, fmt.Errorf("%s: %w: platform in manifest does not match target platform", root.Digest, errdef.ErrNotFound)
+	default:
+		return ocispec.Descriptor{}, fmt.Errorf("%s: %s: %w", root.Digest, root.MediaType, errdef.ErrUnsupported)
+	}
+}
+
+// getPlatformFromConfig returns a platform object which is made up from the
+// fields in config blob.
+func getPlatformFromConfig(ctx context.Context, src content.ReadOnlyStorage, desc ocispec.Descriptor, targetConfigMediaType string) (*ocispec.Platform, error) {
+	if desc.MediaType != targetConfigMediaType {
+		return nil, fmt.Errorf("fail to recognize platform from unknown config %s: expect %s", desc.MediaType, targetConfigMediaType)
+	}
+
+	rc, err := src.Fetch(ctx, desc)
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+
+	var platform ocispec.Platform
+	if err = json.NewDecoder(rc).Decode(&platform); err != nil && err != io.EOF {
+		return nil, err
+	}
+
+	return &platform, nil
+}

--- a/vendor/oras.land/oras-go/v2/internal/registryutil/proxy.go
+++ b/vendor/oras.land/oras-go/v2/internal/registryutil/proxy.go
@@ -1,0 +1,102 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package registryutil
+
+import (
+	"context"
+	"io"
+	"sync"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/content"
+	"oras.land/oras-go/v2/internal/cas"
+	"oras.land/oras-go/v2/internal/ioutil"
+	"oras.land/oras-go/v2/registry"
+)
+
+// ReferenceStorage represents a CAS that supports registry.ReferenceFetcher.
+type ReferenceStorage interface {
+	content.ReadOnlyStorage
+	registry.ReferenceFetcher
+}
+
+// Proxy is a caching proxy dedicated for registry.ReferenceFetcher.
+// The first fetch call of a described content will read from the remote and
+// cache the fetched content.
+// The subsequent fetch call will read from the local cache.
+type Proxy struct {
+	registry.ReferenceFetcher
+	*cas.Proxy
+}
+
+// NewProxy creates a proxy for the `base` ReferenceStorage, using the `cache`
+// storage as the cache.
+func NewProxy(base ReferenceStorage, cache content.Storage) *Proxy {
+	return &Proxy{
+		ReferenceFetcher: base,
+		Proxy:            cas.NewProxy(base, cache),
+	}
+}
+
+// FetchReference fetches the content identified by the reference from the
+// remote and cache the fetched content.
+func (p *Proxy) FetchReference(ctx context.Context, reference string) (ocispec.Descriptor, io.ReadCloser, error) {
+	target, rc, err := p.ReferenceFetcher.FetchReference(ctx, reference)
+	if err != nil {
+		return ocispec.Descriptor{}, nil, err
+	}
+
+	// skip caching if the content already exists in cache
+	exists, err := p.Cache.Exists(ctx, target)
+	if err != nil {
+		return ocispec.Descriptor{}, nil, err
+	}
+	if exists {
+		return target, rc, nil
+	}
+
+	// cache content while reading
+	pr, pw := io.Pipe()
+	var wg sync.WaitGroup
+	wg.Add(1)
+	var pushErr error
+	go func() {
+		defer wg.Done()
+		pushErr = p.Cache.Push(ctx, target, pr)
+		if pushErr != nil {
+			pr.CloseWithError(pushErr)
+		}
+	}()
+	closer := ioutil.CloserFunc(func() error {
+		rcErr := rc.Close()
+		if err := pw.Close(); err != nil {
+			return err
+		}
+		wg.Wait()
+		if pushErr != nil {
+			return pushErr
+		}
+		return rcErr
+	})
+
+	return target, struct {
+		io.Reader
+		io.Closer
+	}{
+		Reader: io.TeeReader(rc, pw),
+		Closer: closer,
+	}, nil
+}

--- a/vendor/oras.land/oras-go/v2/internal/status/tracker.go
+++ b/vendor/oras.land/oras-go/v2/internal/status/tracker.go
@@ -1,0 +1,43 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"sync"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/internal/descriptor"
+)
+
+// Tracker tracks content status described by a descriptor.
+type Tracker struct {
+	status sync.Map // map[descriptor.Descriptor]chan struct{}
+}
+
+// NewTracker creates a new content status tracker.
+func NewTracker() *Tracker {
+	return &Tracker{}
+}
+
+// TryCommit tries to commit the work for the target descriptor.
+// Returns true if committed. A channel is also returned for sending
+// notifications. Once the work is done, the channel should be closed.
+// Returns false if the work is done or still in progress.
+func (t *Tracker) TryCommit(target ocispec.Descriptor) (chan struct{}, bool) {
+	key := descriptor.FromOCI(target)
+	status, exists := t.status.LoadOrStore(key, make(chan struct{}))
+	return status.(chan struct{}), !exists
+}

--- a/vendor/oras.land/oras-go/v2/pack.go
+++ b/vendor/oras.land/oras-go/v2/pack.go
@@ -1,0 +1,439 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oras
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"regexp"
+	"time"
+
+	specs "github.com/opencontainers/image-spec/specs-go"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/content"
+	"oras.land/oras-go/v2/errdef"
+	"oras.land/oras-go/v2/internal/spec"
+)
+
+const (
+	// MediaTypeUnknownConfig is the default config mediaType used
+	//   - for [Pack] when PackOptions.PackImageManifest is true and
+	//     PackOptions.ConfigDescriptor is not specified.
+	//   - for [PackManifest] when packManifestVersion is PackManifestVersion1_0
+	//     and PackManifestOptions.ConfigDescriptor is not specified.
+	MediaTypeUnknownConfig = "application/vnd.unknown.config.v1+json"
+
+	// MediaTypeUnknownArtifact is the default artifactType used for [Pack]
+	// when PackOptions.PackImageManifest is false and artifactType is
+	// not specified.
+	MediaTypeUnknownArtifact = "application/vnd.unknown.artifact.v1"
+)
+
+var (
+	// ErrInvalidDateTimeFormat is returned by [Pack] and [PackManifest] when
+	// AnnotationArtifactCreated or AnnotationCreated is provided, but its value
+	// is not in RFC 3339 format.
+	// Reference: https://www.rfc-editor.org/rfc/rfc3339#section-5.6
+	ErrInvalidDateTimeFormat = errors.New("invalid date and time format")
+
+	// ErrMissingArtifactType is returned by [PackManifest] when
+	// packManifestVersion is PackManifestVersion1_1 and artifactType is
+	// empty and the config media type is set to
+	// "application/vnd.oci.empty.v1+json".
+	ErrMissingArtifactType = errors.New("missing artifact type")
+)
+
+// PackManifestVersion represents the manifest version used for [PackManifest].
+type PackManifestVersion int
+
+const (
+	// PackManifestVersion1_0 represents the OCI Image Manifest defined in
+	// image-spec v1.0.2.
+	// Reference: https://github.com/opencontainers/image-spec/blob/v1.0.2/manifest.md
+	PackManifestVersion1_0 PackManifestVersion = 1
+
+	// PackManifestVersion1_1_RC4 represents the OCI Image Manifest defined
+	// in image-spec v1.1.0-rc4.
+	// Reference: https://github.com/opencontainers/image-spec/blob/v1.1.0-rc4/manifest.md
+	//
+	// Deprecated: This constant is deprecated and not recommended for future use.
+	// Use [PackManifestVersion1_1] instead.
+	PackManifestVersion1_1_RC4 PackManifestVersion = PackManifestVersion1_1
+
+	// PackManifestVersion1_1 represents the OCI Image Manifest defined in
+	// image-spec v1.1.0.
+	// Reference: https://github.com/opencontainers/image-spec/blob/v1.1.0/manifest.md
+	PackManifestVersion1_1 PackManifestVersion = 2
+)
+
+// PackManifestOptions contains optional parameters for [PackManifest].
+type PackManifestOptions struct {
+	// Subject is the subject of the manifest.
+	// This option is only valid when PackManifestVersion is
+	// NOT PackManifestVersion1_0.
+	Subject *ocispec.Descriptor
+
+	// Layers is the layers of the manifest.
+	Layers []ocispec.Descriptor
+
+	// ManifestAnnotations is the annotation map of the manifest.
+	ManifestAnnotations map[string]string
+
+	// ConfigDescriptor is a pointer to the descriptor of the config blob.
+	// If not nil, ConfigAnnotations will be ignored.
+	ConfigDescriptor *ocispec.Descriptor
+
+	// ConfigAnnotations is the annotation map of the config descriptor.
+	// This option is valid only when ConfigDescriptor is nil.
+	ConfigAnnotations map[string]string
+}
+
+// mediaTypeRegexp checks the format of media types.
+// References:
+//   - https://github.com/opencontainers/image-spec/blob/v1.1.0/schema/defs-descriptor.json#L7
+//   - https://datatracker.ietf.org/doc/html/rfc6838#section-4.2
+var mediaTypeRegexp = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9!#$&-^_.+]{0,126}/[A-Za-z0-9][A-Za-z0-9!#$&-^_.+]{0,126}$`)
+
+// PackManifest generates an OCI Image Manifest based on the given parameters
+// and pushes the packed manifest to a content storage using pusher. The version
+// of the manifest to be packed is determined by packManifestVersion
+// (Recommended value: PackManifestVersion1_1).
+//
+//   - If packManifestVersion is [PackManifestVersion1_1]:
+//     artifactType MUST NOT be empty unless opts.ConfigDescriptor is specified.
+//   - If packManifestVersion is [PackManifestVersion1_0]:
+//     if opts.ConfigDescriptor is nil, artifactType will be used as the
+//     config media type; if artifactType is empty,
+//     "application/vnd.unknown.config.v1+json" will be used.
+//     if opts.ConfigDescriptor is NOT nil, artifactType will be ignored.
+//
+// artifactType and opts.ConfigDescriptor.MediaType MUST comply with RFC 6838.
+//
+// If succeeded, returns a descriptor of the packed manifest.
+func PackManifest(ctx context.Context, pusher content.Pusher, packManifestVersion PackManifestVersion, artifactType string, opts PackManifestOptions) (ocispec.Descriptor, error) {
+	switch packManifestVersion {
+	case PackManifestVersion1_0:
+		return packManifestV1_0(ctx, pusher, artifactType, opts)
+	case PackManifestVersion1_1:
+		return packManifestV1_1(ctx, pusher, artifactType, opts)
+	default:
+		return ocispec.Descriptor{}, fmt.Errorf("PackManifestVersion(%v): %w", packManifestVersion, errdef.ErrUnsupported)
+	}
+}
+
+// PackOptions contains optional parameters for [Pack].
+//
+// Deprecated: This type is deprecated and not recommended for future use.
+// Use [PackManifestOptions] instead.
+type PackOptions struct {
+	// Subject is the subject of the manifest.
+	Subject *ocispec.Descriptor
+
+	// ManifestAnnotations is the annotation map of the manifest.
+	ManifestAnnotations map[string]string
+
+	// PackImageManifest controls whether to pack an OCI Image Manifest or not.
+	//   - If true, pack an OCI Image Manifest.
+	//   - If false, pack an OCI Artifact Manifest (deprecated).
+	//
+	// Default value: false.
+	PackImageManifest bool
+
+	// ConfigDescriptor is a pointer to the descriptor of the config blob.
+	// If not nil, artifactType will be implied by the mediaType of the
+	// specified ConfigDescriptor, and ConfigAnnotations will be ignored.
+	// This option is valid only when PackImageManifest is true.
+	ConfigDescriptor *ocispec.Descriptor
+
+	// ConfigAnnotations is the annotation map of the config descriptor.
+	// This option is valid only when PackImageManifest is true
+	// and ConfigDescriptor is nil.
+	ConfigAnnotations map[string]string
+}
+
+// Pack packs the given blobs, generates a manifest for the pack,
+// and pushes it to a content storage.
+//
+// When opts.PackImageManifest is true, artifactType will be used as the
+// the config descriptor mediaType of the image manifest.
+//
+// If succeeded, returns a descriptor of the manifest.
+//
+// Deprecated: This method is deprecated and not recommended for future use.
+// Use [PackManifest] instead.
+func Pack(ctx context.Context, pusher content.Pusher, artifactType string, blobs []ocispec.Descriptor, opts PackOptions) (ocispec.Descriptor, error) {
+	if opts.PackImageManifest {
+		return packManifestV1_1_RC2(ctx, pusher, artifactType, blobs, opts)
+	}
+	return packArtifact(ctx, pusher, artifactType, blobs, opts)
+}
+
+// packArtifact packs an Artifact manifest as defined in image-spec v1.1.0-rc2.
+// Reference: https://github.com/opencontainers/image-spec/blob/v1.1.0-rc2/artifact.md
+func packArtifact(ctx context.Context, pusher content.Pusher, artifactType string, blobs []ocispec.Descriptor, opts PackOptions) (ocispec.Descriptor, error) {
+	if artifactType == "" {
+		artifactType = MediaTypeUnknownArtifact
+	}
+
+	annotations, err := ensureAnnotationCreated(opts.ManifestAnnotations, spec.AnnotationArtifactCreated)
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+	manifest := spec.Artifact{
+		MediaType:    spec.MediaTypeArtifactManifest,
+		ArtifactType: artifactType,
+		Blobs:        blobs,
+		Subject:      opts.Subject,
+		Annotations:  annotations,
+	}
+	return pushManifest(ctx, pusher, manifest, manifest.MediaType, manifest.ArtifactType, manifest.Annotations)
+}
+
+// packManifestV1_0 packs an image manifest defined in image-spec v1.0.2.
+// Reference: https://github.com/opencontainers/image-spec/blob/v1.0.2/manifest.md
+func packManifestV1_0(ctx context.Context, pusher content.Pusher, artifactType string, opts PackManifestOptions) (ocispec.Descriptor, error) {
+	if opts.Subject != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("subject is not supported for manifest version %v: %w", PackManifestVersion1_0, errdef.ErrUnsupported)
+	}
+
+	// prepare config
+	var configDesc ocispec.Descriptor
+	if opts.ConfigDescriptor != nil {
+		if err := validateMediaType(opts.ConfigDescriptor.MediaType); err != nil {
+			return ocispec.Descriptor{}, fmt.Errorf("invalid config mediaType format: %w", err)
+		}
+		configDesc = *opts.ConfigDescriptor
+	} else {
+		if artifactType == "" {
+			artifactType = MediaTypeUnknownConfig
+		} else if err := validateMediaType(artifactType); err != nil {
+			return ocispec.Descriptor{}, fmt.Errorf("invalid artifactType format: %w", err)
+		}
+		var err error
+		configDesc, err = pushCustomEmptyConfig(ctx, pusher, artifactType, opts.ConfigAnnotations)
+		if err != nil {
+			return ocispec.Descriptor{}, err
+		}
+	}
+
+	annotations, err := ensureAnnotationCreated(opts.ManifestAnnotations, ocispec.AnnotationCreated)
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+	if opts.Layers == nil {
+		opts.Layers = []ocispec.Descriptor{} // make it an empty array to prevent potential server-side bugs
+	}
+	manifest := ocispec.Manifest{
+		Versioned: specs.Versioned{
+			SchemaVersion: 2, // historical value. does not pertain to OCI or docker version
+		},
+		Config:      configDesc,
+		MediaType:   ocispec.MediaTypeImageManifest,
+		Layers:      opts.Layers,
+		Annotations: annotations,
+	}
+	return pushManifest(ctx, pusher, manifest, manifest.MediaType, manifest.Config.MediaType, manifest.Annotations)
+}
+
+// packManifestV1_1_RC2 packs an image manifest as defined in image-spec
+// v1.1.0-rc2.
+// Reference: https://github.com/opencontainers/image-spec/blob/v1.1.0-rc2/manifest.md
+func packManifestV1_1_RC2(ctx context.Context, pusher content.Pusher, configMediaType string, layers []ocispec.Descriptor, opts PackOptions) (ocispec.Descriptor, error) {
+	if configMediaType == "" {
+		configMediaType = MediaTypeUnknownConfig
+	}
+
+	// prepare config
+	var configDesc ocispec.Descriptor
+	if opts.ConfigDescriptor != nil {
+		configDesc = *opts.ConfigDescriptor
+	} else {
+		var err error
+		configDesc, err = pushCustomEmptyConfig(ctx, pusher, configMediaType, opts.ConfigAnnotations)
+		if err != nil {
+			return ocispec.Descriptor{}, err
+		}
+	}
+
+	annotations, err := ensureAnnotationCreated(opts.ManifestAnnotations, ocispec.AnnotationCreated)
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+	if layers == nil {
+		layers = []ocispec.Descriptor{} // make it an empty array to prevent potential server-side bugs
+	}
+	manifest := ocispec.Manifest{
+		Versioned: specs.Versioned{
+			SchemaVersion: 2, // historical value. does not pertain to OCI or docker version
+		},
+		Config:      configDesc,
+		MediaType:   ocispec.MediaTypeImageManifest,
+		Layers:      layers,
+		Subject:     opts.Subject,
+		Annotations: annotations,
+	}
+	return pushManifest(ctx, pusher, manifest, manifest.MediaType, manifest.Config.MediaType, manifest.Annotations)
+}
+
+// packManifestV1_1 packs an image manifest defined in image-spec v1.1.0.
+// Reference: https://github.com/opencontainers/image-spec/blob/v1.1.0/manifest.md#guidelines-for-artifact-usage
+func packManifestV1_1(ctx context.Context, pusher content.Pusher, artifactType string, opts PackManifestOptions) (ocispec.Descriptor, error) {
+	if artifactType == "" && (opts.ConfigDescriptor == nil || opts.ConfigDescriptor.MediaType == ocispec.MediaTypeEmptyJSON) {
+		// artifactType MUST be set when config.mediaType is set to the empty value
+		return ocispec.Descriptor{}, ErrMissingArtifactType
+	}
+	if artifactType != "" {
+		if err := validateMediaType(artifactType); err != nil {
+			return ocispec.Descriptor{}, fmt.Errorf("invalid artifactType format: %w", err)
+		}
+	}
+
+	// prepare config
+	var emptyBlobExists bool
+	var configDesc ocispec.Descriptor
+	if opts.ConfigDescriptor != nil {
+		if err := validateMediaType(opts.ConfigDescriptor.MediaType); err != nil {
+			return ocispec.Descriptor{}, fmt.Errorf("invalid config mediaType format: %w", err)
+		}
+		configDesc = *opts.ConfigDescriptor
+	} else {
+		// use the empty descriptor for config
+		configDesc = ocispec.DescriptorEmptyJSON
+		configDesc.Annotations = opts.ConfigAnnotations
+		configBytes := ocispec.DescriptorEmptyJSON.Data
+		// push config
+		if err := pushIfNotExist(ctx, pusher, configDesc, configBytes); err != nil {
+			return ocispec.Descriptor{}, fmt.Errorf("failed to push config: %w", err)
+		}
+		emptyBlobExists = true
+	}
+
+	annotations, err := ensureAnnotationCreated(opts.ManifestAnnotations, ocispec.AnnotationCreated)
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+	if len(opts.Layers) == 0 {
+		// use the empty descriptor as the single layer
+		layerDesc := ocispec.DescriptorEmptyJSON
+		layerData := ocispec.DescriptorEmptyJSON.Data
+		if !emptyBlobExists {
+			if err := pushIfNotExist(ctx, pusher, layerDesc, layerData); err != nil {
+				return ocispec.Descriptor{}, fmt.Errorf("failed to push layer: %w", err)
+			}
+		}
+		opts.Layers = []ocispec.Descriptor{layerDesc}
+	}
+
+	manifest := ocispec.Manifest{
+		Versioned: specs.Versioned{
+			SchemaVersion: 2, // historical value. does not pertain to OCI or docker version
+		},
+		Config:       configDesc,
+		MediaType:    ocispec.MediaTypeImageManifest,
+		Layers:       opts.Layers,
+		Subject:      opts.Subject,
+		ArtifactType: artifactType,
+		Annotations:  annotations,
+	}
+	return pushManifest(ctx, pusher, manifest, manifest.MediaType, manifest.ArtifactType, manifest.Annotations)
+}
+
+// pushIfNotExist pushes data described by desc if it does not exist in the
+// target.
+func pushIfNotExist(ctx context.Context, pusher content.Pusher, desc ocispec.Descriptor, data []byte) error {
+	if ros, ok := pusher.(content.ReadOnlyStorage); ok {
+		exists, err := ros.Exists(ctx, desc)
+		if err != nil {
+			return fmt.Errorf("failed to check existence: %s: %s: %w", desc.Digest.String(), desc.MediaType, err)
+		}
+		if exists {
+			return nil
+		}
+	}
+
+	if err := pusher.Push(ctx, desc, bytes.NewReader(data)); err != nil && !errors.Is(err, errdef.ErrAlreadyExists) {
+		return fmt.Errorf("failed to push: %s: %s: %w", desc.Digest.String(), desc.MediaType, err)
+	}
+	return nil
+}
+
+// pushManifest marshals manifest into JSON bytes and pushes it.
+func pushManifest(ctx context.Context, pusher content.Pusher, manifest any, mediaType string, artifactType string, annotations map[string]string) (ocispec.Descriptor, error) {
+	manifestJSON, err := json.Marshal(manifest)
+	if err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("failed to marshal manifest: %w", err)
+	}
+	manifestDesc := content.NewDescriptorFromBytes(mediaType, manifestJSON)
+	// populate ArtifactType and Annotations of the manifest into manifestDesc
+	manifestDesc.ArtifactType = artifactType
+	manifestDesc.Annotations = annotations
+	// push manifest
+	if err := pusher.Push(ctx, manifestDesc, bytes.NewReader(manifestJSON)); err != nil && !errors.Is(err, errdef.ErrAlreadyExists) {
+		return ocispec.Descriptor{}, fmt.Errorf("failed to push manifest: %w", err)
+	}
+	return manifestDesc, nil
+}
+
+// pushCustomEmptyConfig generates and pushes an empty config blob.
+func pushCustomEmptyConfig(ctx context.Context, pusher content.Pusher, mediaType string, annotations map[string]string) (ocispec.Descriptor, error) {
+	// Use an empty JSON object here, because some registries may not accept
+	// empty config blob.
+	// As of September 2022, GAR is known to return 400 on empty blob upload.
+	// See https://github.com/oras-project/oras-go/issues/294 for details.
+	configBytes := []byte("{}")
+	configDesc := content.NewDescriptorFromBytes(mediaType, configBytes)
+	configDesc.Annotations = annotations
+	// push config
+	if err := pushIfNotExist(ctx, pusher, configDesc, configBytes); err != nil {
+		return ocispec.Descriptor{}, fmt.Errorf("failed to push config: %w", err)
+	}
+	return configDesc, nil
+}
+
+// ensureAnnotationCreated ensures that annotationCreatedKey is in annotations,
+// and that its value conforms to RFC 3339. Otherwise returns a new annotation
+// map with annotationCreatedKey created.
+func ensureAnnotationCreated(annotations map[string]string, annotationCreatedKey string) (map[string]string, error) {
+	if createdTime, ok := annotations[annotationCreatedKey]; ok {
+		// if annotationCreatedKey is provided, validate its format
+		if _, err := time.Parse(time.RFC3339, createdTime); err != nil {
+			return nil, fmt.Errorf("%w: %v", ErrInvalidDateTimeFormat, err)
+		}
+		return annotations, nil
+	}
+
+	// copy the original annotation map
+	copied := make(map[string]string, len(annotations)+1)
+	maps.Copy(copied, annotations)
+
+	// set creation time in RFC 3339 format
+	// reference: https://github.com/opencontainers/image-spec/blob/v1.1.0-rc2/annotations.md#pre-defined-annotation-keys
+	now := time.Now().UTC()
+	copied[annotationCreatedKey] = now.Format(time.RFC3339)
+	return copied, nil
+}
+
+// validateMediaType validates the format of mediaType.
+func validateMediaType(mediaType string) error {
+	if !mediaTypeRegexp.MatchString(mediaType) {
+		return fmt.Errorf("%s: %w", mediaType, errdef.ErrInvalidMediaType)
+	}
+	return nil
+}

--- a/vendor/oras.land/oras-go/v2/target.go
+++ b/vendor/oras.land/oras-go/v2/target.go
@@ -1,0 +1,43 @@
+/*
+Copyright The ORAS Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oras
+
+import "oras.land/oras-go/v2/content"
+
+// Target is a CAS with generic tags.
+type Target interface {
+	content.Storage
+	content.TagResolver
+}
+
+// GraphTarget is a CAS with generic tags that supports direct predecessor node
+// finding.
+type GraphTarget interface {
+	content.GraphStorage
+	content.TagResolver
+}
+
+// ReadOnlyTarget represents a read-only Target.
+type ReadOnlyTarget interface {
+	content.ReadOnlyStorage
+	content.Resolver
+}
+
+// ReadOnlyGraphTarget represents a read-only GraphTarget.
+type ReadOnlyGraphTarget interface {
+	content.ReadOnlyGraphStorage
+	content.Resolver
+}


### PR DESCRIPTION
**Purpose of the PR**

- Added new cssc patch commands which would be instrumental in enabling continuous patching on the registry. These commands perform filtration either using filter policy or from a filter file in Json format from local file system if dry run is chosen.
- In this PR, only dry run functionality is enabled. The actual patch implementation will be added in upcoming PRs.
- Refactored current list tag implementation to return a tag list so that it can be re-used both in tag and cssc commands + updated corresponding tests
- Added a bunch of unit tests covering both success and failure scenarios for the cssc command
- Refactored and restructured to move non cmd related methods to internal package for cssc and tag
- Verified by running changes locally ensuring all unit tests pass and also via ACR task
