### PR TITLE
fix: docker build with golang 1.22 + FIPS enabled

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # default owners for everything in the repo
-* @sajayantony @Wwwsylvia @shizhMSFT @northtyphoon @wangxiaoxuan273 @wju-MSFT @gildardogmsft
+* @sajayantony @Wwwsylvia @shizhMSFT @northtyphoon @wangxiaoxuan273 @wju-MSFT @gildardogmsft @estebanreyl

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /go/src/github.com/Azure/acr-cli
 COPY . .
 RUN make binaries && mv bin/acr /usr/bin/acr
 
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0@sha256:4e16d123da8f90c10fe6cb7281b2f33f261b3e39cb6f1057ab85da6492eeaac7
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
 RUN tdnf check-update \
     && tdnf --refresh install -y \
         ca-certificates-microsoft \

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ binaries: $(BINARIES) ## Build the binaries
 FORCE:
 bin/%: cmd/% FORCE
 	@echo "+ $@${BINARY_SUFFIX}"
-	@CGO_ENABLED=0 go build ${GO_GCFLAGS} ${GO_BUILD_FLAGS} -o $@${BINARY_SUFFIX} ${GO_LDFLAGS} ${GO_TAGS} ./$<
+	@CGO_ENABLED=1 go build ${GO_GCFLAGS} ${GO_BUILD_FLAGS} -o $@${BINARY_SUFFIX} ${GO_LDFLAGS} ${GO_TAGS} ./$<
 
 .PHONY: build
 build: ## Build the Go packages

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,5 +37,5 @@ steps:
 - task: Docker@2
   inputs:
     command: build
-    Dockerfile: Dockerfile
+    Dockerfile: **/Dockerfile
   displayName: Build container image

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,3 +33,9 @@ steps:
     GOOS=linux make
   workingDirectory: '$(ModulePath)'
   displayName: 'Build'
+
+- task: Docker@2
+  inputs:
+    command: build
+    Dockerfile: Dockerfile
+  displayName: Build container image

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,5 +37,5 @@ steps:
 - task: Docker@2
   inputs:
     command: build
-    Dockerfile: **/Dockerfile
-  displayName: Build container image
+    Dockerfile: '**/Dockerfile'
+  displayName: 'Build container image'


### PR DESCRIPTION
**Purpose of the PR**

- enable cgo to work with golang 1.22 + FIPS enabled
- add docker build in pr validation
- update owner list

Fixes #261 