### PR TITLE
fixing docker build for acr CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /go/src/github.com/Azure/acr-cli
 COPY . .
 RUN make binaries && mv bin/acr /usr/bin/acr
 
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0@sha256:4e16d123da8f90c10fe6cb7281b2f33f261b3e39cb6f1057ab85da6492eeaac7
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
 RUN tdnf check-update \
     && tdnf --refresh install -y \
         ca-certificates-microsoft \

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ binaries: $(BINARIES) ## Build the binaries
 FORCE:
 bin/%: cmd/% FORCE
 	@echo "+ $@${BINARY_SUFFIX}"
-	@CGO_ENABLED=0 go build ${GO_GCFLAGS} ${GO_BUILD_FLAGS} -o $@${BINARY_SUFFIX} ${GO_LDFLAGS} ${GO_TAGS} ./$<
+	@CGO_ENABLED=1 go build ${GO_GCFLAGS} ${GO_BUILD_FLAGS} -o $@${BINARY_SUFFIX} ${GO_LDFLAGS} ${GO_TAGS} ./$<
 
 .PHONY: build
 build: ## Build the Go packages


### PR DESCRIPTION
**Fix Docker build**

- 

Fixes #
Update to use CGO to work with fips go build
removed digest from base image to use latest mariner core image