### PR TITLE
chore: upgrade go version from 1.18.1 to 1.21 in releaser action

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -25,7 +25,7 @@ jobs:
       - name: setup go environment
         uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
-          go-version: '1.18.1'
+          go-version: '1.21'
 
       - name: run goreleaser
         uses: goreleaser/goreleaser-action@5742e2a039330cbb23ebf35f046f814d4c6ff811 # v5.1.0


### PR DESCRIPTION
**Purpose of the PR**

- fix release issue due to incompatible go version 

Fixes #300 