### PR TITLE
Change filtertimeout var from uint64 to int64

### DIFF
--- a/cmd/acr/annotate.go
+++ b/cmd/acr/annotate.go
@@ -46,7 +46,7 @@ var (
 type annotateParameters struct {
 	*rootParameters
 	filters       []string
-	filterTimeout uint64
+	filterTimeout int64
 	artifactType  string
 	annotations   []string
 	untagged      bool
@@ -136,7 +136,7 @@ func newAnnotateCmd(rootParams *rootParameters) *cobra.Command {
 
 	cmd.Flags().StringArrayVarP(&annotateParams.filters, "filter", "f", nil, `Specify the repository and a regular expression filter for the tag name. If a tag matches the filter, it will be annotated. If multiple tags refer to the same manifest and a tag matches the filter, the manifest will be annotated.
 																				Note: If backtracking is used in the regexp it's possible for the expression to run into an infinite loop. The default timeout is set to 1 minute for evaluation of any filter expression. Use the '--filter-timeout-seconds' option to set a different value`)
-	cmd.Flags().Uint64Var(&annotateParams.filterTimeout, "filter-timeout-seconds", defaultRegexpMatchTimeoutSeconds, "This limits the evaluation of the regex filter, and will return a timeout error if this duration is exceeded during a single evaluation. If written incorrectly a regexp filter with backtracking can result in an infinite loop")
+	cmd.Flags().Int64Var(&annotateParams.filterTimeout, "filter-timeout-seconds", defaultRegexpMatchTimeoutSeconds, "This limits the evaluation of the regex filter, and will return a timeout error if this duration is exceeded during a single evaluation. If written incorrectly a regexp filter with backtracking can result in an infinite loop")
 	cmd.Flags().StringVar(&annotateParams.artifactType, "artifact-type", "", "The configurable artifact type for an organization")
 	cmd.Flags().StringSliceVarP(&annotateParams.annotations, "annotations", "a", []string{}, "The configurable annotation key value that can be specified one or more times")
 	cmd.Flags().BoolVar(&annotateParams.untagged, "untagged", false, "If the untagged flag is set, all the manifests that do not have any tags associated to them will also be annotated, except if they belong to a manifest list that contains at least one tag")
@@ -159,7 +159,7 @@ func annotateTags(ctx context.Context,
 	artifactType string,
 	annotations []string,
 	tagFilter string,
-	regexpMatchTimeoutSeconds uint64,
+	regexpMatchTimeoutSeconds int64,
 	dryRun bool) (int, error) {
 
 	if !dryRun {

--- a/cmd/acr/purge.go
+++ b/cmd/acr/purge.go
@@ -58,7 +58,7 @@ var (
 
 // Default settings for regexp2
 const (
-	defaultRegexpMatchTimeoutSeconds uint64 = 60
+	defaultRegexpMatchTimeoutSeconds int64 = 60
 )
 
 // purgeParameters defines the parameters that the purge command uses (including the registry name, username and password).
@@ -67,7 +67,7 @@ type purgeParameters struct {
 	ago           string
 	keep          int
 	filters       []string
-	filterTimeout uint64
+	filterTimeout int64
 	untagged      bool
 	dryRun        bool
 	concurrency   int
@@ -160,7 +160,7 @@ func newPurgeCmd(rootParams *rootParameters) *cobra.Command {
 	cmd.Flags().IntVar(&purgeParams.keep, "keep", 0, "Number of latest to-be-deleted tags to keep, use this when you want to keep at least x number of latest tags that could be deleted meeting all other filter criteria")
 	cmd.Flags().StringArrayVarP(&purgeParams.filters, "filter", "f", nil, "Specify the repository and a regular expression filter for the tag name, if a tag matches the filter and is older than the duration specified in ago it will be deleted. Note: If backtracking is used in the regexp it's possible for the expression to run into an infinite loop. The default timeout is set to 1 minute for evaluation of any filter expression. Use the '--filter-timeout-seconds' option to set a different value.")
 	cmd.Flags().StringArrayVarP(&purgeParams.configs, "config", "c", nil, "Authentication config paths (e.g. C://Users/docker/config.json)")
-	cmd.Flags().Uint64Var(&purgeParams.filterTimeout, "filter-timeout-seconds", defaultRegexpMatchTimeoutSeconds, "This limits the evaluation of the regex filter, and will return a timeout error if this duration is exceeded during a single evaluation. If written incorrectly a regexp filter with backtracking can result in an infinite loop.")
+	cmd.Flags().Int64Var(&purgeParams.filterTimeout, "filter-timeout-seconds", defaultRegexpMatchTimeoutSeconds, "This limits the evaluation of the regex filter, and will return a timeout error if this duration is exceeded during a single evaluation. If written incorrectly a regexp filter with backtracking can result in an infinite loop.")
 	cmd.Flags().IntVar(&purgeParams.concurrency, "concurrency", defaultPoolSize, concurrencyDescription)
 	cmd.Flags().BoolP("help", "h", false, "Print usage")
 	cmd.MarkFlagRequired("filter")
@@ -169,7 +169,7 @@ func newPurgeCmd(rootParams *rootParameters) *cobra.Command {
 }
 
 // purgeTags deletes all tags that are older than the ago value and that match the tagFilter string.
-func purgeTags(ctx context.Context, acrClient api.AcrCLIClientInterface, poolSize int, loginURL string, repoName string, ago string, tagFilter string, keep int, regexpMatchTimeoutSeconds uint64) (int, error) {
+func purgeTags(ctx context.Context, acrClient api.AcrCLIClientInterface, poolSize int, loginURL string, repoName string, ago string, tagFilter string, keep int, regexpMatchTimeoutSeconds int64) (int, error) {
 	fmt.Printf("Deleting tags for repository: %s\n", repoName)
 	agoDuration, err := parseDuration(ago)
 	if err != nil {
@@ -330,7 +330,7 @@ func purgeDanglingManifests(ctx context.Context, acrClient api.AcrCLIClientInter
 }
 
 // dryRunPurge outputs everything that would be deleted if the purge command was executed
-func dryRunPurge(ctx context.Context, acrClient api.AcrCLIClientInterface, loginURL string, repoName string, ago string, filter string, untagged bool, keep int, regexMatchTimeout uint64) (int, int, error) {
+func dryRunPurge(ctx context.Context, acrClient api.AcrCLIClientInterface, loginURL string, repoName string, ago string, filter string, untagged bool, keep int, regexMatchTimeout int64) (int, int, error) {
 	deletedTagsCount := 0
 	deletedManifestsCount := 0
 	// In order to keep track if a manifest would get deleted a map is defined that as a key has the manifest

--- a/cmd/common/image_functions.go
+++ b/cmd/common/image_functions.go
@@ -25,7 +25,7 @@ const (
 	headerLink                                            = "Link"
 	mediaTypeDockerManifestList                           = "application/vnd.docker.distribution.manifest.list.v2+json"
 	defaultRegexpOptions             regexp2.RegexOptions = regexp2.RE2 // This option will turn on compatibility mode so that it uses the group rules in regexp
-	defaultRegexpMatchTimeoutSeconds uint64               = 60
+	defaultRegexpMatchTimeoutSeconds int64                = 60
 	mediaTypeArtifactManifest                             = "application/vnd.oci.artifact.manifest.v1+json"
 )
 
@@ -48,7 +48,7 @@ func GetAllRepositoryNames(ctx context.Context, client acrapi.BaseClientAPI) ([]
 }
 
 // GetMatchingRepos get all repositories in current registry, that match the provided regular expression
-func GetMatchingRepos(repoNames []string, repoRegex string, regexMatchTimeout uint64) ([]string, error) {
+func GetMatchingRepos(repoNames []string, repoRegex string, regexMatchTimeout int64) ([]string, error) {
 	filter, err := BuildRegexFilter(repoRegex, regexMatchTimeout)
 	if err != nil {
 		return nil, err
@@ -97,7 +97,7 @@ func GetRepositoryAndTagRegex(filter string) (string, string, error) {
 }
 
 // CollectTagFilters collects all matching repos and collects the associated tag filters
-func CollectTagFilters(ctx context.Context, rawFilters []string, client acrapi.BaseClientAPI, regexMatchTimeout uint64) (map[string]string, error) {
+func CollectTagFilters(ctx context.Context, rawFilters []string, client acrapi.BaseClientAPI, regexMatchTimeout int64) (map[string]string, error) {
 	allRepoNames, err := GetAllRepositoryNames(ctx, client)
 	if err != nil {
 		return nil, err
@@ -270,7 +270,7 @@ func UpdateForManifestWithoutSubjectToDelete(ctx context.Context, manifest acr.M
 }
 
 // BuildRegexFilter compiles a regex state machine from a regex expression
-func BuildRegexFilter(expression string, regexpMatchTimeoutSeconds uint64) (*regexp2.Regexp, error) {
+func BuildRegexFilter(expression string, regexpMatchTimeoutSeconds int64) (*regexp2.Regexp, error) {
 	regexp, err := regexp2.Compile(expression, defaultRegexpOptions)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**Purpose of the PR**
This addresses a minor codeql issue leading to pipeline failures due to trying to cast an uint64 time value to time.Duration (which is a type alias for int(64). This can cause an overflow. Changed to use regular int64.