### PR TITLE
Do not list repositories if the repository filters are not regexes

### DIFF
--- a/cmd/acr/purge_test.go
+++ b/cmd/acr/purge_test.go
@@ -734,11 +734,21 @@ func TestCollectTagFilters(t *testing.T) {
 		mockClient.AssertExpectations(t)
 	})
 
-	t.Run("SingleRepo", func(t *testing.T) {
+	t.Run("SingleRepoWithRegex", func(t *testing.T) {
 		assert := assert.New(t)
 		mockClient := &mocks.BaseClientAPI{}
 		mockClient.On("GetRepositories", mock.Anything, "", mock.Anything).Return(ManyRepositoriesResult, nil).Once()
 		mockClient.On("GetRepositories", mock.Anything, mock.Anything, mock.Anything).Return(NoRepositoriesResult, nil).Once()
+		filters, err := common.CollectTagFilters(testCtx, []string{testRepo + ".?:.*"}, mockClient, 60)
+		assert.Equal(1, len(filters), "Number of found should be one")
+		assert.Equal(".*", filters[testRepo], "Filter for test repo should be .*")
+		assert.Equal(nil, err, "Error should be nil")
+		mockClient.AssertExpectations(t)
+	})
+
+	t.Run("SingleRepoWithoutRegex", func(t *testing.T) {
+		assert := assert.New(t)
+		mockClient := &mocks.BaseClientAPI{}
 		filters, err := common.CollectTagFilters(testCtx, []string{testRepo + ":.*"}, mockClient, 60)
 		assert.Equal(1, len(filters), "Number of found should be one")
 		assert.Equal(".*", filters[testRepo], "Filter for test repo should be .*")
@@ -764,7 +774,7 @@ func TestCollectTagFilters(t *testing.T) {
 		mockClient := &mocks.BaseClientAPI{}
 		mockClient.On("GetRepositories", mock.Anything, "", mock.Anything).Return(ManyRepositoriesResult, nil).Once()
 		mockClient.On("GetRepositories", mock.Anything, mock.Anything, mock.Anything).Return(NoRepositoriesResult, nil).Once()
-		filters, err := common.CollectTagFilters(testCtx, []string{"ba:.*"}, mockClient, 60)
+		filters, err := common.CollectTagFilters(testCtx, []string{"ba?:.*"}, mockClient, 60)
 		assert.Equal(0, len(filters), "Number of found repos should be zero")
 		assert.Equal(nil, err, "Error should be nil")
 		mockClient.AssertExpectations(t)
@@ -775,7 +785,7 @@ func TestCollectTagFilters(t *testing.T) {
 		mockClient := &mocks.BaseClientAPI{}
 		mockClient.On("GetRepositories", mock.Anything, "", mock.Anything).Return(ManyRepositoriesResult, nil).Once()
 		mockClient.On("GetRepositories", mock.Anything, mock.Anything, mock.Anything).Return(NoRepositoriesResult, nil).Once()
-		filters, err := common.CollectTagFilters(testCtx, []string{"foo/bar:.*"}, mockClient, 60)
+		filters, err := common.CollectTagFilters(testCtx, []string{"foo/bar?:.*"}, mockClient, 60)
 		assert.Equal(1, len(filters), "Number of found repos should be one")
 		assert.Equal(nil, err, "Error should be nil")
 		mockClient.AssertExpectations(t)
@@ -786,7 +796,7 @@ func TestCollectTagFilters(t *testing.T) {
 		mockClient := &mocks.BaseClientAPI{}
 		mockClient.On("GetRepositories", mock.Anything, "", mock.Anything).Return(ManyRepositoriesResult, nil).Once()
 		mockClient.On("GetRepositories", mock.Anything, mock.Anything, mock.Anything).Return(NoRepositoriesResult, nil).Once()
-		filters, err := common.CollectTagFilters(testCtx, []string{"foo/bar:(?:.*)"}, mockClient, 60)
+		filters, err := common.CollectTagFilters(testCtx, []string{"foo/bar?:(?:.*)"}, mockClient, 60)
 		assert.Equal(1, len(filters), "Number of found repos should be one")
 		assert.Equal(nil, err, "Error should be nil")
 		mockClient.AssertExpectations(t)
@@ -840,7 +850,7 @@ func TestCollectTagFilters(t *testing.T) {
 		assert := assert.New(t)
 		mockClient := &mocks.BaseClientAPI{}
 		mockClient.On("GetRepositories", mock.Anything, "", mock.Anything).Return(NoRepositoriesResult, nil).Once()
-		filters, err := common.CollectTagFilters(testCtx, []string{testRepo + ":.*"}, mockClient, 60)
+		filters, err := common.CollectTagFilters(testCtx, []string{testRepo + "?:.*"}, mockClient, 60)
 		assert.Equal(0, len(filters), "Number of found repos should be zero")
 		assert.Equal(nil, err, "Error should be nil")
 		mockClient.AssertExpectations(t)
@@ -849,8 +859,6 @@ func TestCollectTagFilters(t *testing.T) {
 	t.Run("EmptyRepoRegex", func(t *testing.T) {
 		assert := assert.New(t)
 		mockClient := &mocks.BaseClientAPI{}
-		mockClient.On("GetRepositories", mock.Anything, "", mock.Anything).Return(ManyRepositoriesResult, nil).Once()
-		mockClient.On("GetRepositories", mock.Anything, mock.Anything, mock.Anything).Return(NoRepositoriesResult, nil).Once()
 		_, err := common.CollectTagFilters(testCtx, []string{":.*"}, mockClient, 60)
 		assert.NotEqual(nil, err, "Error should not be nil")
 		mockClient.AssertExpectations(t)
@@ -859,8 +867,6 @@ func TestCollectTagFilters(t *testing.T) {
 	t.Run("EmptyTagRegex", func(t *testing.T) {
 		assert := assert.New(t)
 		mockClient := &mocks.BaseClientAPI{}
-		mockClient.On("GetRepositories", mock.Anything, "", mock.Anything).Return(ManyRepositoriesResult, nil).Once()
-		mockClient.On("GetRepositories", mock.Anything, mock.Anything, mock.Anything).Return(NoRepositoriesResult, nil).Once()
 		_, err := common.CollectTagFilters(testCtx, []string{testRepo + ".*:"}, mockClient, 60)
 		assert.NotEqual(nil, err, "Error should not be nil")
 		mockClient.AssertExpectations(t)

--- a/cmd/common/image_functions.go
+++ b/cmd/common/image_functions.go
@@ -98,9 +98,34 @@ func GetRepositoryAndTagRegex(filter string) (string, string, error) {
 
 // CollectTagFilters collects all matching repos and collects the associated tag filters
 func CollectTagFilters(ctx context.Context, rawFilters []string, client acrapi.BaseClientAPI, regexMatchTimeout int64) (map[string]string, error) {
-	allRepoNames, err := GetAllRepositoryNames(ctx, client)
-	if err != nil {
-		return nil, err
+	var allRepoNames []string
+
+	// Bypass listing the repositories if there are no regex in the repository name filters
+	notRegexRegex := regexp2.MustCompile(`^[a-z0-9-\/]+$`, defaultRegexpOptions)
+	listRepositories := false
+	for _, filter := range rawFilters {
+		repoRegex, _, err := GetRepositoryAndTagRegex(filter)
+		if err != nil {
+			return nil, err
+		}
+
+		notRegex, err := notRegexRegex.MatchString(repoRegex)
+		if err != nil {
+			return nil, err
+		}
+		if !notRegex {
+			listRepositories = true
+			break
+		}
+
+		allRepoNames = append(allRepoNames, repoRegex)
+	}
+
+	if listRepositories {
+		var err error
+		if allRepoNames, err = GetAllRepositoryNames(ctx, client); err != nil {
+			return nil, err
+		}
 	}
 
 	tagFilters := map[string]string{}


### PR DESCRIPTION
**Purpose of the PR**
As explained in https://github.com/Azure/acr-cli/pull/353, listing all the repositories can possibly never complete, or with the workaround from that PR, it can still take hours in large ACRs.

The problem is that in a very common scenario (the repository not being a regex), there is absolutely no need to list the repositories in the first place.

This PR simply checks that none of the repository parts of the provided filters are regex and if that's the case, use those as repository names instead of calling the potentially very expensive `GetAllRepositoryNames`.

We use this in our ACRs with ACR tasks for each known large repositories like `purge --filter '<REPOSITORY>:.*'` and it is instantaneous instead of taking hours.