### PR TITLE
fix(cssc): 31695069 Fix to return unique set of repos and tags in filteredRepos

### DIFF
--- a/internal/cssc/cssc.go
+++ b/internal/cssc/cssc.go
@@ -192,6 +192,7 @@ func ApplyFilterAndGetFilteredList(ctx context.Context, acrClient api.AcrCLIClie
 		patchTagRegex = floatingTagRegex
 	}
 
+	uniqueFilteredRepos := make(map[string]bool)
 	for _, filterRepo := range filter.Repositories {
 		// Create a tag map for each repository, where the key will be the base tag and the value will be the list of tags matching the tag convention from the filter
 		tagMap := make(map[string][]string)
@@ -268,11 +269,15 @@ func ApplyFilterAndGetFilteredList(ctx context.Context, acrClient api.AcrCLIClie
 			if latestTag == baseTag {
 				latestTag = "N/A"
 			}
-			filteredRepos = append(filteredRepos, FilteredRepository{
-				Repository: filterRepo.Repository,
-				Tag:        baseTag,
-				PatchTag:   latestTag,
-			})
+			key := fmt.Sprintf("%s-%s-%s", filterRepo.Repository, baseTag, latestTag)
+			if !uniqueFilteredRepos[key] {
+				uniqueFilteredRepos[key] = true
+				filteredRepos = append(filteredRepos, FilteredRepository{
+					Repository: filterRepo.Repository,
+					Tag:        baseTag,
+					PatchTag:   latestTag,
+				})
+			}
 		}
 	}
 	return filteredRepos, artifactsNotFound, nil


### PR DESCRIPTION
**Purpose of the PR**

- Code changes to return unique set of matching filtered repos
- Added 2 new unit tests to test for this scenario

Bug: https://msazure.visualstudio.com/AzureContainerRegistry/_workitems/edit/31695069/?view=edit

Before Fix:
![image](https://github.com/user-attachments/assets/f0b34e9e-a984-4627-ade1-a4a0b3c8645d)

After Fix:
![image](https://github.com/user-attachments/assets/900201a0-b938-495b-b0da-4d9f529aac7b)
