### PR TITLE
fix: improve error handling in UpdateForManifestWithoutSubjectToDelete

### DIFF
--- a/cmd/common/image_functions.go
+++ b/cmd/common/image_functions.go
@@ -250,8 +250,7 @@ func UpdateForManifestWithoutSubjectToDelete(ctx context.Context, manifest acr.M
 		if err != nil {
 			// Check if the error is autorest.DetailedError with status code not found
 			if detailedErr, ok := err.(autorest.DetailedError); ok && detailedErr.StatusCode == http.StatusNotFound {
-				fmt.Println("Manifest", *manifest.Digest, "not found, adding to delete candidates")
-				candidatesToDelete = append(candidatesToDelete, manifest)
+				fmt.Println("Manifest", *manifest.Digest, "not found, skip it")
 				return candidatesToDelete, nil
 			}
 			// For other errors, return the error

--- a/cmd/common/image_functions.go
+++ b/cmd/common/image_functions.go
@@ -247,7 +247,9 @@ func UpdateForManifestWithoutSubjectToDelete(ctx context.Context, manifest acr.M
 		var manifestBytes []byte
 		manifestBytes, err := acrClient.GetManifest(ctx, repoName, *manifest.Digest)
 		if err != nil {
-			return nil, err
+			fmt.Println("Error getting manifest bytes for", *manifest.Digest, ":", err, "continuing with the next manifest")
+			candidatesToDelete = append(candidatesToDelete, manifest)
+			return candidatesToDelete, nil
 		}
 		// this struct defines a customized struct for manifests which
 		// is used to parse the content of a manifest references a subject


### PR DESCRIPTION
It should be ignored if manifest not found instead of return error and interrupt all the process

**Purpose of the PR**

- Fixes #459 