### PR TITLE
feat: honor `--ago` cutoff when purging untagged manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ The duration should be of the form \[integer\]d\[string\] where the first intege
 
 #### Untagged flag
 
-To delete all the manifests that do not have any tags linked to them, the `--untagged` flag should be set.
+To delete all the manifests that do not have any tags linked to them, the `--untagged` flag should be set. The manifest cleanup respects the same `--ago` cutoff that is used for tag deletions, so recently-untagged images that are newer than the configured age threshold are preserved.
 
 ```sh
 acr purge \

--- a/cmd/acr/annotate.go
+++ b/cmd/acr/annotate.go
@@ -307,7 +307,7 @@ func annotateUntaggedManifests(ctx context.Context,
 	// Contrary to getTagsToAnnotate, getManifests gets all the manifests at once.
 	// This was done because if there is a manifest that has no tag but is referenced by a multiarch manifest that has tags then it
 	// should not be annotated.
-	manifestsToAnnotate, err := repository.GetUntaggedManifests(ctx, poolSize, acrClient, repoName, true, nil, dryRun, includeLocked)
+	manifestsToAnnotate, err := repository.GetUntaggedManifests(ctx, poolSize, acrClient, repoName, true, nil, dryRun, includeLocked, nil)
 	if err != nil {
 		return -1, err
 	}

--- a/cmd/repository/image_functions.go
+++ b/cmd/repository/image_functions.go
@@ -158,7 +158,7 @@ func GetLastTagFromResponse(resultTags *acr.RepositoryTagsType) string {
 // the manifest should also not have a tag and not have a subject manifest.
 // Param manifestToTagsCountMap is an optional map that can be used to pass the count of tags for each manifest that we know would be deleted if the command is exectued
 // under dryRun conditions. Its ignored if the dryRun flag is false.
-func GetUntaggedManifests(ctx context.Context, poolSize int, acrClient api.AcrCLIClientInterface, repoName string, preserveAllOCIManifests bool, manifestToDeletedTagsCountMap map[string]int, dryRun bool, includeLocked bool) ([]acr.ManifestAttributesBase, error) {
+func GetUntaggedManifests(ctx context.Context, poolSize int, acrClient api.AcrCLIClientInterface, repoName string, preserveAllOCIManifests bool, manifestToDeletedTagsCountMap map[string]int, dryRun bool, includeLocked bool, deleteBefore *time.Time) ([]acr.ManifestAttributesBase, error) {
 	lastManifestDigest := ""
 	var manifestsToDelete []acr.ManifestAttributesBase
 	resultManifests, err := acrClient.GetAcrManifests(ctx, repoName, "", lastManifestDigest)
@@ -255,6 +255,21 @@ func GetUntaggedManifests(ctx context.Context, poolSize int, acrClient api.AcrCL
 			}
 
 			// _____MANIFEST IS UNTAGGED BUT MAY BE PROTECTED_____
+			if deleteBefore != nil {
+				if manifest.LastUpdateTime == nil {
+					continue
+				}
+
+				lastUpdateTime, err := time.Parse(time.RFC3339Nano, *manifest.LastUpdateTime)
+				if err != nil {
+					return nil, err
+				}
+
+				if !lastUpdateTime.Before(*deleteBefore) {
+					continue
+				}
+			}
+
 			// TODO: #468 I am a little unclear as to why this was ever an option but respecting it for now. Its not used by the purge scenarios only for
 			// the annotate command.
 			if preserveAllOCIManifests {


### PR DESCRIPTION
- Apply the purge command’s age threshold to manifest cleanup by deriving the cutoff in purgeDanglingManifests and filtering untagged manifests by LastUpdateTime before deletion so only older content is removed.
- Keep annotation support aligned with the new helper signature by passing a nil cutoff when collecting untagged manifests for annotate workflows.
- Document the age-respecting manifest purge behavior and add unit plus smoke coverage to confirm recent untagged images are preserved until they age past the cutoff.

Discovered while finding answer for #515 