### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # default owners for everything in the repo
-* @sajayantony @Wwwsylvia @shizhMSFT @northtyphoon @wangxiaoxuan273 @wju-MSFT @gildardogmsft @estebanreyl @Ruchii-27
+* @sajayantony @northtyphoon @wangxiaoxuan273  @gildardogmsft @estebanreyl @Ruchii-27


### PR DESCRIPTION
Retire inactive maintainers from CODEOWNERS.

Note that @gildardogmsft and @Ruchii-27 don't have write access to this repo so it still shows errors 