### PR TITLE
target go-mod version for github release workflow

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -25,7 +25,7 @@ jobs:
       - name: setup go environment
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version: '1.21'
+          go-version-file: 'go.mod'
 
       - name: run goreleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0


### PR DESCRIPTION
**Purpose of the PR**

-  I saw the release workflow failed here https://github.com/Azure/acr-cli/actions/runs/22203651598/job/64222495655#step:6:13 due to us using a higher go version in the repo. This matches it to the go version to avoid that.

Should fix #588
